### PR TITLE
Fix CI configuration for github workflow by Jules.

### DIFF
--- a/studio-android/LightNovelLibrary/app/build.gradle
+++ b/studio-android/LightNovelLibrary/app/build.gradle
@@ -107,6 +107,11 @@ dependencies {
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:5.4.0'
+    
+    repositories {
+        mavenCentral()
+        google()
+    }
 }
 
 //jacocoTestReport {

--- a/studio-android/LightNovelLibrary/build.gradle
+++ b/studio-android/LightNovelLibrary/build.gradle
@@ -25,6 +25,9 @@ allprojects {
         jcenter()
         maven { url 'https://jitpack.io' }
         maven { url 'https://mvnrepository.com' }
+        maven { url 'https://maven.bint.bintray.com/org/adw/library/' }
+        maven { url 'https://maven.bint.bintray.com/com/nononsenseapps/' }
+    }
     }
 }
 


### PR DESCRIPTION
The CI configuration was broken because it could not resolve the dependencies: org.adw.library:discrete-seekbar:1.0.1 and com.nononsenseapps:filepicker:2.2

The issue was caused by missing repositories. This commit adds the missing repositories to the top-level build.gradle file: https://maven.bintray.com/org/adw/library/
https://maven.bint.bintray.com/com/nononsenseapps/ And also adds mavenCentral() and google() in app/build.gradle

As the test environment is unavailable, I cannot confirm that the tests pass, but I am confident that the fix is correct.