### PR TITLE
Fix BadTokenException in CheckAppNewVersion

### DIFF
--- a/studio-android/LightNovelLibrary/app/src/main/java/org/mewx/wenku8/async/CheckAppNewVersion.java
+++ b/studio-android/LightNovelLibrary/app/src/main/java/org/mewx/wenku8/async/CheckAppNewVersion.java
@@ -78,22 +78,25 @@ public class CheckAppNewVersion extends AsyncTask<Void, Void, Integer> {
             if (verboseMode) {
                 Toast.makeText(ctx, ctx.getResources().getString(R.string.system_update_latest_version), Toast.LENGTH_SHORT).show();
             }
-        } else if (ctx instanceof Activity && ((Activity) ctx).hasWindowFocus()) {
-            // Note that checking window focus is needed: https://stackoverflow.com/a/41118674/4206925
+        } else if (ctx instanceof Activity) {
+            Activity activity = (Activity) ctx;
+            if (!activity.isFinishing() && !activity.isDestroyed() && activity.hasWindowFocus()) {
+                // Note that checking window focus is needed: https://stackoverflow.com/a/41118674/4206925
 
-            // Update to new version.
-            new MaterialDialog.Builder(ctx)
-                    .theme(Theme.LIGHT)
-                    .title(R.string.system_update_found_new)
-                    .content(R.string.system_update_jump_to_page)
-                    .positiveText(R.string.dialog_positive_sure)
-                    .negativeText(R.string.dialog_negative_biao)
-                    .negativeColorRes(R.color.menu_text_color)
-                    .onPositive((dialog, which) -> {
-                        Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(GlobalConfig.blogPageUrl));
-                        ctx.startActivity(browserIntent);
-                    })
-                    .show();
+                // Update to new version.
+                new MaterialDialog.Builder(activity)
+                        .theme(Theme.LIGHT)
+                        .title(R.string.system_update_found_new)
+                        .content(R.string.system_update_jump_to_page)
+                        .positiveText(R.string.dialog_positive_sure)
+                        .negativeText(R.string.dialog_negative_biao)
+                        .negativeColorRes(R.color.menu_text_color)
+                        .onPositive((dialog, which) -> {
+                            Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(GlobalConfig.blogPageUrl));
+                            activity.startActivity(browserIntent);
+                        })
+                        .show();
+            }
         }
     }
 }


### PR DESCRIPTION
The `CheckAppNewVersion` async task attempts to show a dialog in `onPostExecute`. If the activity is finished or destroyed before the task completes, calling `dialog.show()` causes a `WindowManager$BadTokenException`.

This change adds checks for `!activity.isFinishing()` and `!activity.isDestroyed()` (available since API 17) to ensure the activity is valid before showing the dialog.

Refactored the code to cast `Context` to `Activity` once and use the local variable.

---
*PR created automatically by Jules for task [13764472070931638465](https://jules.google.com/task/13764472070931638465) started by @MewX*