### PR TITLE
Fix crashes in NovelInfoActivity due to lifecycle issues

### DIFF
--- a/studio-android/LightNovelLibrary/app/src/main/java/org/mewx/wenku8/activity/NovelInfoActivity.java
+++ b/studio-android/LightNovelLibrary/app/src/main/java/org/mewx/wenku8/activity/NovelInfoActivity.java
@@ -985,27 +985,41 @@ public class NovelInfoActivity extends BaseMaterialActivity {
 
         protected void onPostExecute(Wenku8Error.ErrorCode result)
         {
+            if (isFinishing() || isDestroyed()) return;
+
             if (result == Wenku8Error.ErrorCode.USER_CANCELLED_TASK) {
                 // user cancelled
                 Toast.makeText(NovelInfoActivity.this, R.string.system_manually_cancelled, Toast.LENGTH_LONG).show();
-                if (pDialog != null)
-                    pDialog.dismiss();
-                onResume();
+                try {
+                    if (pDialog != null && pDialog.isShowing())
+                        pDialog.dismiss();
+                } catch (IllegalArgumentException e) {
+                    // ignored
+                }
+                updateUI();
                 isLoading = false;
                 return;
             } else if (result == Wenku8Error.ErrorCode.NETWORK_ERROR) {
                 Toast.makeText(NovelInfoActivity.this, getResources().getString(R.string.system_network_error), Toast.LENGTH_LONG).show();
-                if (pDialog != null)
-                    pDialog.dismiss();
-                onResume();
+                try {
+                    if (pDialog != null && pDialog.isShowing())
+                        pDialog.dismiss();
+                } catch (IllegalArgumentException e) {
+                    // ignored
+                }
+                updateUI();
                 isLoading = false;
                 return;
             } else if (result == Wenku8Error.ErrorCode.XML_PARSE_FAILED
                     || result == Wenku8Error.ErrorCode.SERVER_RETURN_NOTHING) {
                 Toast.makeText(NovelInfoActivity.this, "Server returned strange data! (copyright reason?)", Toast.LENGTH_LONG).show();
-                if (pDialog != null)
-                    pDialog.dismiss();
-                onResume();
+                try {
+                    if (pDialog != null && pDialog.isShowing())
+                        pDialog.dismiss();
+                } catch (IllegalArgumentException e) {
+                    // ignored
+                }
+                updateUI();
                 isLoading = false;
                 return;
             }
@@ -1013,8 +1027,12 @@ public class NovelInfoActivity extends BaseMaterialActivity {
             // cache successfully
             Toast.makeText(NovelInfoActivity.this, "OK", Toast.LENGTH_LONG).show();
             isLoading = false;
-            if (pDialog != null)
-                pDialog.dismiss();
+            try {
+                if (pDialog != null && pDialog.isShowing())
+                    pDialog.dismiss();
+            } catch (IllegalArgumentException e) {
+                // ignored
+            }
 
             refreshInfoFromLocal();
         }
@@ -1086,8 +1104,14 @@ public class NovelInfoActivity extends BaseMaterialActivity {
         @Override
         protected void onPostExecute(Wenku8Error.ErrorCode err) {
             super.onPostExecute(err);
+            if (isFinishing() || isDestroyed()) return;
 
-            md.dismiss();
+            try {
+                if (md != null && md.isShowing()) md.dismiss();
+            } catch (IllegalArgumentException e) {
+                // ignored
+            }
+
             if(err == Wenku8Error.ErrorCode.SYSTEM_1_SUCCEEDED) {
                 Toast.makeText(NovelInfoActivity.this, getResources().getString(R.string.bookshelf_removed), Toast.LENGTH_SHORT).show();
                 if(fabFavorite != null)
@@ -1197,24 +1221,38 @@ public class NovelInfoActivity extends BaseMaterialActivity {
         @Override
         protected void onPostExecute(Wenku8Error.ErrorCode errorCode) {
             super.onPostExecute(errorCode);
+            if (isFinishing() || isDestroyed()) return;
+
             if (errorCode == Wenku8Error.ErrorCode.USER_CANCELLED_TASK) {
                 // user cancelled
                 Toast.makeText(NovelInfoActivity.this, R.string.system_manually_cancelled, Toast.LENGTH_LONG).show();
-                if (md != null) md.dismiss();
-                onResume();
+                try {
+                    if (md != null && md.isShowing()) md.dismiss();
+                } catch (IllegalArgumentException e) {
+                    // ignored
+                }
+                updateUI();
                 loading = false;
                 return;
             } else if (errorCode == Wenku8Error.ErrorCode.NETWORK_ERROR) {
                 Toast.makeText(NovelInfoActivity.this, getResources().getString(R.string.system_network_error), Toast.LENGTH_LONG).show();
-                if (md != null) md.dismiss();
-                onResume();
+                try {
+                    if (md != null && md.isShowing()) md.dismiss();
+                } catch (IllegalArgumentException e) {
+                    // ignored
+                }
+                updateUI();
                 loading = false;
                 return;
             } else if (errorCode == Wenku8Error.ErrorCode.XML_PARSE_FAILED
                     || errorCode == Wenku8Error.ErrorCode.SERVER_RETURN_NOTHING) {
                 Toast.makeText(NovelInfoActivity.this, "Server returned strange data! (copyright reason?)", Toast.LENGTH_LONG).show();
-                if (md != null) md.dismiss();
-                onResume();
+                try {
+                    if (md != null && md.isShowing()) md.dismiss();
+                } catch (IllegalArgumentException e) {
+                    // ignored
+                }
+                updateUI();
                 loading = false;
                 return;
             }
@@ -1222,7 +1260,11 @@ public class NovelInfoActivity extends BaseMaterialActivity {
             // cache successfully
             Toast.makeText(NovelInfoActivity.this, "OK", Toast.LENGTH_LONG).show();
             loading = false;
-            if (md != null) md.dismiss();
+            try {
+                if (md != null && md.isShowing()) md.dismiss();
+            } catch (IllegalArgumentException e) {
+                // ignored
+            }
             refreshInfoFromLocal();
         }
     }
@@ -1230,7 +1272,10 @@ public class NovelInfoActivity extends BaseMaterialActivity {
     @Override
     protected void onResume() {
         super.onResume();
+        updateUI();
+    }
 
+    private void updateUI() {
         // return from search activity
         final Drawable upArrow = getResources().getDrawable(R.drawable.ic_svg_back);
         if(getSupportActionBar() != null && upArrow != null) {


### PR DESCRIPTION
This PR fixes three distinct crashes in `NovelInfoActivity`:
1.  `IllegalStateException: FragmentManager has been destroyed`: Caused by manually calling `onResume()` from `onPostExecute`. Replaced with a new `updateUI()` method.
2.  `IllegalArgumentException` in `WindowManagerGlobal.findViewLocked`: Caused by dismissing dialogs after the activity is destroyed. Added checks for `isFinishing()` and `isDestroyed()` and wrapped `dismiss()` calls in try-catch blocks.
3.  Similar `IllegalArgumentException` in `AsyncRemoveBookFromCloud`.

Testing:
- Verified compilation with `./gradlew assembleAlphaDebug`.
- Validated code changes manually.

---
*PR created automatically by Jules for task [8659018325587298001](https://jules.google.com/task/8659018325587298001) started by @MewX*