### PR TITLE
Fixing a parser crash on non-responses, and running CI before the merge rather than after

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,10 +1,16 @@
 name: Android CI
 
+# The pull_request trigger is deliberately unfiltered. It used to be limited to PRs based on
+# master, but development lands on the release branch (v1.30) first and only reaches master at
+# release time -- so a PR into v1.30 ran no checks at all and the post-merge push to v1.30 was
+# the first build of the change. That is the wrong order when the app cannot be built without
+# an Android SDK: contributors working without one (or in a sandbox that cannot reach
+# dl.google.com) have no local check either, which leaves nothing between an unbuilt commit and
+# the release branch.
 on:
   push:
     branches: [ "master", "v*" ]
   pull_request:
-    branches: [ "master" ]
 
 defaults:
   run:
@@ -12,8 +18,8 @@ defaults:
 
 jobs:
   # Split out from the emulator job deliberately. These two run independently so that an
-  # emulator that will not boot costs 2 tests of signal rather than all 46: previously a
-  # single step ran assembleAlpha, the JVM tests and the instrumented tests together, so an
+  # emulator that will not boot costs the 23 instrumented tests rather than all 91: previously
+  # a single step ran assembleAlpha, the JVM tests and the instrumented tests together, so an
   # emulator failure meant the JVM tests never reported at all.
   build-and-test:
     name: Build and JVM unit tests

--- a/studio-android/LightNovelLibrary/STABILITY_PLAN.md
+++ b/studio-android/LightNovelLibrary/STABILITY_PLAN.md
@@ -3,18 +3,36 @@
 Status: draft, derived from a read-through of `app/` and `api/` at commit `5e00d42`.
 
 **Progress:** "Testing strategy" step 1 (move device-independent tests to the JVM), **Phase 0
-(instrumentation)** and **Phase 1 (items 1–7)** are implemented. Phase 0 has not yet *collected*
+(instrumentation)** and **Phase 1 (items 1–8)** are implemented. Phase 0 has not yet *collected*
 anything — the ranking below is still inference from reading the code, and stays that way until a
 release ships and reports come back. Phase 1 was written to be safe to land without that data;
 Phase 2's ordering still needs it. Phases 2–4 are proposed, not done.
 
-**Caveat on the Phase 1 commits:** they were written in an environment with no Android SDK and no
-emulator, so `./gradlew assembleAlpha testAlphaDebugUnitTest` has never been run against them.
-The JVM read-loop tests in `LightCacheStreamTest` were executed by extracting the method into a
-standalone harness (8 tests pass; 6 of them fail against the previous implementation), and
-`AsyncTaskTracker`'s logic likewise against a stub AsyncTask. Everything else — every guard
-clause, and the Robolectric tests for the parser validation — is unexecuted. **CI is the first
-real check.**
+**The Phase 1 caveat is discharged.** Those commits were written with no Android SDK and no
+emulator, so this section used to warn that `./gradlew assembleAlpha testAlphaDebugUnitTest` had
+never been run against them and that CI would be the first real check. It has now run: CI is
+green on `3bc1827` (the merge of #185) on both jobs — the build and the JVM suite, and the
+instrumented tests, which confirms the emulator repair below as well. Items 1–7 are compiled and
+tested code.
+
+**What can still be checked without a device, and what cannot.** Nothing here builds without an
+Android SDK, and the SDK is not always fetchable: `dl.google.com` is blocked in the sandbox these
+changes are written in, which rules out Robolectric locally too — it needs
+`androidx.test:monitor`, published only on Google's Maven, which redirects to the same blocked
+host. `repo1.maven.org` and `maven.google.com` itself are reachable; the artifacts behind them
+are not. The loop that does work for a change made without a device:
+
+1. **Extract the pure-logic method into a standalone `javac`/`java` harness** with hand-written
+   stubs for the Android calls it makes, and run the old and new implementations side by side on
+   the same inputs. The read loop in item 3 was checked this way (8 tests pass; 6 fail against
+   the previous implementation), `AsyncTaskTracker` against a stub `AsyncTask`, and item 8 below
+   against nine inputs, three of which throw on the previous implementation.
+2. **Open the PR and let CI build it.** CI now runs on *every* pull request rather than only
+   ones based on master (see "Testing strategy"), so the first build of a change happens before
+   it merges instead of after.
+
+Guard clauses, anything touching a view, and the Robolectric tests still cannot be executed
+anywhere but CI and a device.
 
 ## Diagnosis
 
@@ -235,6 +253,34 @@ Four things turned out differently from the plan as written, and are worth recor
    otherwise. Cheap, and it is exactly the kind of silent failure Phase 0 instrumentation
    cannot see.
 
+8. **Stop `parseNovelItemList` throwing on a non-response.** Not in the original plan — found
+   while auditing the list parsers item 7 deliberately left alone. They were left alone because
+   "they already return empty collections, which callers distinguish", which is true of every
+   list parser except this one: it is the only parser in `global/api/` with no `try`/`catch`
+   around its body, so anything it throws reaches its caller.
+
+   Its per-item log line read back the element just added — `list.get(list.size() - 1)` — from
+   *outside* the branch that added it. On a quoted token that is not an integer nothing was
+   added, so it indexed an empty list and threw `IndexOutOfBoundsException` out of a `@NonNull`
+   method. `NovelItemListFragment.AsyncGetNovelItemList` calls it inside `doInBackground` and
+   catches `UnsupportedEncodingException` alone, so the throw escaped the task and crashed the
+   app instead of reaching the empty-list path that caller already handles.
+
+   Reachable two ways. The expected one is root cause 4's server-side twin: any well-formed
+   non-response carrying two or more single-quoted values with no integer among them — a
+   captive-portal interstitial, an HTML error page. The unexpected one decided the fix: a
+   **valid** novel list whose XML declaration uses single quotes rather than double,
+   `<?xml version='1.0' encoding='utf-8'?>`, supplies two non-integer tokens ahead of the first
+   `aid` and crashed on the second. Rejecting the response at the first non-integer token — the
+   shape item 7 used for the single-object parsers — would have turned that good list into an
+   empty one. Non-integer tokens are skipped instead, and only the log line moved inside the
+   branch.
+
+   Three tests were added, plus one characterization test recording a quirk found alongside it
+   and deliberately left in place: the parser has no notion of *which* token is the page count,
+   the caller simply takes element 0, so a non-integer page number does not fail — it shifts,
+   and the first novel silently drops out of the list.
+
 Expected outcome: this should remove the majority of crash *volume* without touching
 architecture. Phase 0's data will confirm — and because Phase 0 shipped first, the before/after
 comparison is actually available this time.
@@ -248,6 +294,16 @@ effect of each change is measurable.
    `vid` and re-read the volume from the local cache on the receiving side. Kills
    `TransactionTooLargeException` permanently and makes the reader survive process death for
    free, since ints in an Intent always restore. This is the highest-value item in the plan.
+
+   **Check the cache assumption first — it does not currently hold.** "Re-read the volume from
+   the local cache" assumes `intro/<aid>-volume.xml` is on disk by the time the reader starts.
+   It is written only by `NovelInfoActivity.AsyncUpdateCacheTask`, the explicit download/refresh
+   action. The ordinary online load (`FetchInfoAsyncTask`'s `volumeTask`) fetches exactly the
+   same XML and never writes it, so for any novel the user has merely opened, the receiving
+   Activity would find nothing to read and the reader would fail to open — a worse bug than the
+   one being fixed. Persisting that response in the sender is a prerequisite, not a detail, and
+   it is worth doing on its own: it is also what lets the reader rebuild itself after process
+   death, which is Phase 3's problem for these screens.
 2. **Retire `AsyncTask`.** Do not rewrite all 24 at once. Introduce one small helper
    (`ExecutorService` + main-thread `Handler`, or `androidx.lifecycle` if you are open to
    adding it) and migrate screen by screen, starting with whichever Phase 0 shows is
@@ -321,20 +377,21 @@ appears at first glance. The problem was never the count, it was *where* they ru
 
 | Location | Before | Now | Runs on |
 |---|---|---|---|
-| `app/src/test` | 3 files / 10 tests | **10 files / 44 tests** | JVM, seconds |
-| `app/src/androidTest` | 8 files | **2 files** | emulator, minutes |
+| `app/src/test` | 3 files / 10 tests | **12 files / 68 tests** | JVM, seconds |
+| `app/src/androidTest` | 8 files / 31 tests | **2 files / 23 tests** | emulator, minutes |
 | `api/src/test` | 1 file | 1 file | JVM |
 
-(37 of those tests came from step 1; `CrashReporterTest` added the other 7 in Phase 0.)
+(Step 1 moved the JVM count from 10 to 37; `CrashReporterTest` took it to 44 in Phase 0; Phase 1
+added the rest, mostly `LightCacheStreamTest` and `AsyncTaskTrackerTest`.)
 
 **The emulator flakiness was not theoretical, and CI has been restructured because of it.** The
 run for commit `2525b3b` failed in the emulator step, and because that one step ran
 `assembleAlpha testAlphaDebugUnitTest connectedAlphaDebugAndroidTest` together, the 44 JVM tests
-never reported at all. Three changes to `.github/workflows/android-ci.yml`:
+never reported at all. Four changes to `.github/workflows/android-ci.yml`:
 
 1. **Split into two jobs.** JVM tests no longer depend on an emulator booting. This is the whole
    payoff of having moved those tests off the device: an emulator that will not start now costs
-   2 tests of signal instead of 46.
+   the 23 instrumented tests instead of all 91.
 2. **Enable KVM.** The failure was `ShellCommandUnresponsiveException` during `installCommit`,
    with the emulator console also failing to start — the signature of an emulator running
    unaccelerated. `android-emulator-runner` needs an explicit udev rule on `ubuntu-latest`;
@@ -345,9 +402,15 @@ never reported at all. Three changes to `.github/workflows/android-ci.yml`:
    the API 21 emulator took the uninteresting side of every conditional while being the slowest
    and least reliable image to install onto. Neither remaining instrumented test is
    API-21-specific — `LightCacheTest` only uses `getFilesDir()`.
+4. **Run on every pull request.** The trigger was `pull_request: branches: [master]`, but
+   development lands on the release branch and only reaches master at release time — so a PR
+   into `v1.30` ran no checks at all, and the post-merge push to `v1.30` was the first build of
+   the change. #185 merged that way. For a project that cannot be built without an Android SDK,
+   and whose contributors may not have one, a first check that arrives after the merge is the
+   wrong order; the `pull_request` filter is now removed so the build gates the merge.
 
-Note this means the minSdk floor is no longer verified by CI. That is an accepted trade for two
-tests; if Phase 4 raises `minSdkVersion` anyway the question goes away.
+Note the API 21 → 33 move means the minSdk floor is no longer verified by CI. That is an accepted
+trade for two test classes; if Phase 4 raises `minSdkVersion` anyway the question goes away.
 
 **The codebase already contains the answer.** `WenkuReaderPaginatorTest` injects the
 Android-dependent piece — text measurement — as a lambda:
@@ -407,7 +470,7 @@ inverts the negative test cases. See step 1.
 | Ship | Contents | Risk |
 |---|---|---|
 | v1.30.0 | Phase 0 instrumentation only | none |
-| v1.30.1 | Phase 1 items 1–7 — **implemented, unbuilt** | low, mechanical |
+| v1.30.1 | Phase 1 items 1–7 — **implemented, CI green**; item 8 pending its first CI run | low, mechanical |
 | v1.31 | Phase 2.1 (Intent payloads) + highest-crash screen from 2.2 | medium |
 | v1.32+ | Remainder of Phase 2, Phase 3 | medium |
 

--- a/studio-android/LightNovelLibrary/app/src/main/java/org/mewx/wenku8/global/api/Wenku8Parser.java
+++ b/studio-android/LightNovelLibrary/app/src/main/java/org/mewx/wenku8/global/api/Wenku8Parser.java
@@ -59,9 +59,26 @@ public class Wenku8Parser {
             temp = str.indexOf(SEPARATOR, beg + 1);
             if (beg == -1 || temp == -1) break;
 
-            if(LightTool.isInteger(str.substring(beg + 1, temp)))
-                list.add(Integer.parseInt(str.substring(beg + 1, temp)));
-            Log.v("MewX", "Add novel aid: " + list.get(list.size() - 1));
+            // The log line below used to sit outside this branch, where it read back the
+            // element that had just been added -- so on a quoted token that is not an
+            // integer, nothing was added and it indexed an empty list. Any well-formed
+            // response holding two or more single-quoted values with no integer among them
+            // therefore threw IndexOutOfBoundsException out of this @NonNull method: a
+            // captive-portal or proxy interstitial, an HTML error page, and also a perfectly
+            // valid list whose XML declaration happens to use single quotes
+            // (<?xml version='1.0' encoding='utf-8'?>). The only caller runs this inside
+            // doInBackground and catches UnsupportedEncodingException alone, so it crashed
+            // the app rather than reaching the empty-list path it already handles.
+            //
+            // Non-integer tokens are skipped rather than rejected outright, which is what
+            // keeps that single-quoted declaration parsing into the right list instead of an
+            // empty one.
+            String token = str.substring(beg + 1, temp);
+            if (LightTool.isInteger(token)) {
+                int aid = Integer.parseInt(token);
+                list.add(aid);
+                Log.v("MewX", "Add novel aid: " + aid);
+            }
 
             beg = temp + 1; // prepare for next round
         }

--- a/studio-android/LightNovelLibrary/app/src/main/java/org/mewx/wenku8/global/api/Wenku8Parser.java
+++ b/studio-android/LightNovelLibrary/app/src/main/java/org/mewx/wenku8/global/api/Wenku8Parser.java
@@ -59,25 +59,20 @@ public class Wenku8Parser {
             temp = str.indexOf(SEPARATOR, beg + 1);
             if (beg == -1 || temp == -1) break;
 
-            // The log line below used to sit outside this branch, where it read back the
-            // element that had just been added -- so on a quoted token that is not an
-            // integer, nothing was added and it indexed an empty list. Any well-formed
-            // response holding two or more single-quoted values with no integer among them
-            // therefore threw IndexOutOfBoundsException out of this @NonNull method: a
-            // captive-portal or proxy interstitial, an HTML error page, and also a perfectly
-            // valid list whose XML declaration happens to use single quotes
-            // (<?xml version='1.0' encoding='utf-8'?>). The only caller runs this inside
-            // doInBackground and catches UnsupportedEncodingException alone, so it crashed
-            // the app rather than reaching the empty-list path it already handles.
-            //
-            // Non-integer tokens are skipped rather than rejected outright, which is what
-            // keeps that single-quoted declaration parsing into the right list instead of an
-            // empty one.
+            // Two separate things make this branch load-bearing. The log reads back the
+            // element just added, so from outside the branch it indexed an empty list and
+            // threw out of this @NonNull method on any token that was not an integer. And a
+            // non-integer token is skipped rather than treated as the end of the response:
+            // rejecting at the first would empty out a valid list whose XML declaration uses
+            // single quotes, since <?xml version='1.0' encoding='utf-8'?> supplies two of
+            // them ahead of the first aid. See STABILITY_PLAN.md, Phase 1 item 8.
             String token = str.substring(beg + 1, temp);
             if (LightTool.isInteger(token)) {
-                int aid = Integer.parseInt(token);
-                list.add(aid);
-                Log.v("MewX", "Add novel aid: " + aid);
+                // Not necessarily an aid: element 0 is the page count, and it is read here
+                // rather than above whenever the pre-loop read consumed a non-integer.
+                int value = Integer.parseInt(token);
+                list.add(value);
+                Log.v("MewX", "Add novel list value: " + value);
             }
 
             beg = temp + 1; // prepare for next round

--- a/studio-android/LightNovelLibrary/app/src/test/java/org/mewx/wenku8/global/api/Wenku8ParserTest.java
+++ b/studio-android/LightNovelLibrary/app/src/test/java/org/mewx/wenku8/global/api/Wenku8ParserTest.java
@@ -81,9 +81,9 @@ public class Wenku8ParserTest {
     // of returning empty, because the log line that read back the just-added element sat
     // outside the branch that added it -- so any input carrying two or more single-quoted
     // values with no integer among them indexed an empty list. parseNovelItemList is @NonNull
-    // and its only caller (NovelItemListFragment.AsyncGetNovelItemList) catches
-    // UnsupportedEncodingException alone, so the throw escaped doInBackground and crashed the
-    // app instead of reaching the empty-list path that caller already handles.
+    // and NovelItemListFragment.AsyncGetNovelItemList catches UnsupportedEncodingException
+    // alone, so the throw escaped doInBackground and crashed the app instead of reaching the
+    // empty-list path that caller already handles.
     @Test
     public void testParseNovelItemListWellFormedNonResponse() {
         assertTrue(Wenku8Parser.parseNovelItemList(

--- a/studio-android/LightNovelLibrary/app/src/test/java/org/mewx/wenku8/global/api/Wenku8ParserTest.java
+++ b/studio-android/LightNovelLibrary/app/src/test/java/org/mewx/wenku8/global/api/Wenku8ParserTest.java
@@ -7,6 +7,7 @@ import org.robolectric.annotation.Config;
 
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.GregorianCalendar;
 import java.util.List;
 
@@ -73,6 +74,48 @@ public class Wenku8ParserTest {
     public void testParseNovelItemListInvalid() {
         List<Integer> list = Wenku8Parser.parseNovelItemList("1234");
         assertTrue(list.isEmpty());
+    }
+
+    // Regression. "1234" above exercises the early return for input with no quotes at all; it
+    // never reached the loop. These do. Both used to throw IndexOutOfBoundsException instead
+    // of returning empty, because the log line that read back the just-added element sat
+    // outside the branch that added it -- so any input carrying two or more single-quoted
+    // values with no integer among them indexed an empty list. parseNovelItemList is @NonNull
+    // and its only caller (NovelItemListFragment.AsyncGetNovelItemList) catches
+    // UnsupportedEncodingException alone, so the throw escaped doInBackground and crashed the
+    // app instead of reaching the empty-list path that caller already handles.
+    @Test
+    public void testParseNovelItemListWellFormedNonResponse() {
+        assertTrue(Wenku8Parser.parseNovelItemList(
+                "<meta http-equiv='refresh' content='0;url=http://portal'/>").isEmpty());
+        assertTrue(Wenku8Parser.parseNovelItemList(
+                "<html><body class='error'><p id='msg'>maintenance</p></body></html>").isEmpty());
+    }
+
+    // The fix skips non-integer tokens rather than rejecting the whole response on the first
+    // one, and this is the case that decides between the two: a valid list whose declaration
+    // uses single quotes instead of double. Rejecting would return an empty list for a
+    // response that is entirely well-formed. This input threw before the fix.
+    @Test
+    public void testParseNovelItemListSingleQuotedXmlDeclaration() {
+        final String XML = "<?xml version='1.0' encoding='utf-8'?>\n" +
+                "<result>\n" +
+                "<page num='166'/>\n" +
+                "<item aid='1143'/>\n" +
+                "</result>";
+
+        assertEquals(Arrays.asList(166, 1143), Wenku8Parser.parseNovelItemList(XML));
+    }
+
+    // Characterization, not endorsement. The parser has no notion of which token is the page
+    // count -- it returns every integer it finds and the caller takes element 0 as the total
+    // page count. So a non-integer page number does not fail, it shifts: the first aid is
+    // consumed as the page count and that novel drops out of the list. Recorded so that
+    // changing it is a deliberate act rather than an accident.
+    @Test
+    public void testParseNovelItemListNonIntegerPageNumberShiftsTheList() {
+        assertEquals(Collections.singletonList(7),
+                Wenku8Parser.parseNovelItemList("<page num='x'/><item aid='7'/>"));
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #185. Four commits: one crash fix with tests, one CI trigger fix, one plan update, one review follow-up.

**CI is green on both jobs** — and it ran *on this PR*, which is the point of the second commit below.

## `parseNovelItemList` threw `IndexOutOfBoundsException` on a non-response

Phase 1 item 7 left the list parsers alone because "they already return empty collections, which callers distinguish". That holds for every list parser except this one — it is the only parser in `global/api/` with no `try`/`catch` around its body, so anything it throws reaches its caller.

Its per-item log line read back the element just added, `list.get(list.size() - 1)`, from *outside* the branch that added it. On a quoted token that is not an integer nothing was added, so it indexed an empty list and threw out of a `@NonNull` method. `NovelItemListFragment.AsyncGetNovelItemList` calls it inside `doInBackground` and catches `UnsupportedEncodingException` alone, so the throw escaped the task and crashed the app instead of reaching the empty-list path that caller already handles.

Reachable two ways, both verified in a standalone `javac` harness running the old and new implementations side by side:

| Input | Before | After |
|---|---|---|
| Captive-portal interstitial, HTML error page | **throws** | `[]` |
| Valid list, single-quoted XML declaration | **throws** | `[166, 1143]` |
| Valid list, double-quoted XML declaration | `[166, 1143, …]` | unchanged |

The second row decided the fix. A **valid** novel list whose XML declaration uses single quotes rather than double supplies two non-integer tokens ahead of the first `aid`, and crashed on the second — so rejecting the response at the first non-integer token, the shape item 7 used for the single-object parsers, would have turned a good list into an empty one. Non-integer tokens are skipped instead, and only the log line moved inside the branch, leaving the parse of a valid list byte-for-byte what it was.

Three regression tests, plus a fourth that is characterization rather than a fix: the parser has no notion of *which* token is the page count — the caller takes element 0 — so a non-integer page number does not fail, it shifts, and the first novel silently drops out of the list. Recorded so that changing it is deliberate.

## CI ran after the merge instead of before it

The trigger was `pull_request: branches: [master]`, but development lands on the release branch and only reaches master at release time. A PR into `v1.30` therefore ran no checks at all, and the post-merge push to `v1.30` was the first build of the change — #185 merged that way, with its Phase 1 commits unbuilt until they were already on the release branch.

For a project that cannot be built without an Android SDK, and whose contributors may not have one to hand, a first check arriving after the merge is the wrong order. Removing the filter lets the build gate the merge. This PR is the first to be checked that way, and it checks the change that makes the checking happen.

Also corrected the split-jobs comment, which claimed "2 tests of signal rather than all 46" — the instrumented job is 23 tests across 2 classes and the JVM job 68.

## Plan update

CI is green on `3bc1827` (the merge of #185) on both jobs, so `STABILITY_PLAN.md`'s standing caveat that the Phase 1 commits had never been compiled is discharged, and the emulator repair is confirmed by the same run. It is replaced with what a session working without a device can and cannot check, since that is the recurring constraint here: `dl.google.com` is blocked in the sandbox these changes are written in, which rules out Robolectric locally too (it needs `androidx.test:monitor` from Google's Maven). What does work is extracting the pure logic into a standalone harness and running old against new, then letting CI build the PR.

Also refreshes the test counts, which were three phases out of date, and records a prerequisite for **Phase 2.1** found while reading the launch path: "re-read the volume from the local cache on the receiving side" assumes the volume XML for that novel is on disk, but `intro/{aid}-volume.xml` is written only by `AsyncUpdateCacheTask`, the explicit download action. The ordinary online load fetches the same XML and never writes it, so for a novel the user has merely opened, the receiving Activity would find nothing and the reader would fail to open — worse than the bug being fixed. Persisting it in the sender is part of that item, not a detail.

## Review follow-up

Both Copilot findings were valid and are fixed in the last commit. The local named `aid` was not always one — element 0 is the page count, and it is added inside the loop rather than by the pre-loop read whenever that read consumed a non-integer, which is exactly what the single-quoted-declaration test does. The block comment's call-site half was condensed away, since nothing stops a second caller appearing and making a comment about another file quietly wrong; the history it carried is in `STABILITY_PLAN.md` item 8 and the commit messages.

## Testing

The JVM suite is 68 tests across 12 classes with the three added here, and it passes on this PR. Nothing was built locally — no Android SDK is reachable from the environment this was written in — so CI is the check, which now runs before the merge rather than after it.