### PR TITLE
Reading the novel list by attribute name instead of scanning quoted values

### DIFF
--- a/studio-android/LightNovelLibrary/STABILITY_PLAN.md
+++ b/studio-android/LightNovelLibrary/STABILITY_PLAN.md
@@ -276,10 +276,30 @@ Four things turned out differently from the plan as written, and are worth recor
    empty one. Non-integer tokens are skipped instead, and only the log line moved inside the
    branch.
 
-   Three tests were added, plus one characterization test recording a quirk found alongside it
-   and deliberately left in place: the parser has no notion of *which* token is the page count,
-   the caller simply takes element 0, so a non-integer page number does not fail — it shifts,
-   and the first novel silently drops out of the list.
+   Three tests were added, plus one characterization test recording a quirk found alongside it:
+   the scan had no notion of *which* token was the page count, the caller simply takes element
+   0, so a non-integer page number did not fail — it shifted, and the first novel silently
+   dropped out of the list.
+
+   **Then the scan was replaced outright**, in the follow-up PR, and that characterization test
+   was the thing that made the replacement legible: `parseNovelItemList` reads `page/@num` and
+   `item/@aid` by name through `XmlPullParser`, like every other parser in the file, so the
+   shift quirk is gone rather than recorded and the test now asserts that the novel stays in
+   the list. What decided it was not tidiness but a fragility the scan could not be patched out
+   of: it took *any* single-quoted value in document order, so `<page num='166' cached='2'/>`
+   yielded a phantom novel 2 and `<item type='9' aid='1143'/>` a phantom novel 9. One added
+   attribute on either tag — a live possibility now the API sits behind a Cloudflare Worker
+   relay rather than the site itself — would have injected non-existent novels into every list,
+   failing one at a time rather than failing as a list.
+
+   The scan survives as a private fallback, reached only when the XML parse recognises nothing
+   at all. It is the one thing the scan does better: `XmlPullParser` stops at the first byte of
+   anything that is not the document, so a response that is well-formed only after some leading
+   noise — a PHP notice, a relay banner — parses to nothing, while the scan reads straight past
+   it. There is no way to tell from here how often that happens, so the fallback records a
+   breadcrumb when it fires. **Delete it, and the private method with it, if a release goes by
+   without that breadcrumb appearing.** This is the same measure-then-act shape Phase 0 used for
+   `loadStream`, applied to a tolerance nobody can currently justify or refute.
 
 Expected outcome: this should remove the majority of crash *volume* without touching
 architecture. Phase 0's data will confirm — and because Phase 0 shipped first, the before/after

--- a/studio-android/LightNovelLibrary/STABILITY_PLAN.md
+++ b/studio-android/LightNovelLibrary/STABILITY_PLAN.md
@@ -292,14 +292,20 @@ Four things turned out differently from the plan as written, and are worth recor
    relay rather than the site itself — would have injected non-existent novels into every list,
    failing one at a time rather than failing as a list.
 
-   The scan survives as a private fallback, reached only when the XML parse recognises nothing
-   at all. It is the one thing the scan does better: `XmlPullParser` stops at the first byte of
-   anything that is not the document, so a response that is well-formed only after some leading
-   noise — a PHP notice, a relay banner — parses to nothing, while the scan reads straight past
-   it. There is no way to tell from here how often that happens, so the fallback records a
-   breadcrumb when it fires. **Delete it, and the private method with it, if a release goes by
-   without that breadcrumb appearing.** This is the same measure-then-act shape Phase 0 used for
-   `loadStream`, applied to a tolerance nobody can currently justify or refute.
+   The scan is gone entirely, including as a fallback. It did do one thing better —
+   `XmlPullParser` stops at the first byte of anything that is not the document, so a response
+   that is well-formed only after some leading noise (a PHP notice, a relay banner) parses to
+   nothing, while the scan read straight past it — and the first version of this change kept it
+   for that case alone. Review caught the flaw: a fallback that returns the scan's output
+   reintroduces both the phantom novels and the shift, on exactly the responses nobody can
+   observe. The recovery is a **retry from the document start** instead, so the leading-noise
+   path reads attributes by name like every other path, and there is one parsing implementation
+   rather than two.
+
+   The retry records a breadcrumb when it fires, because there is no way to tell from here
+   whether leading noise is real. **Delete the retry and `indexOfDocumentStart` if a release
+   goes by without that breadcrumb appearing** — the same measure-then-act shape Phase 0 used
+   for `loadStream`, applied to a tolerance nobody can currently justify or refute.
 
 Expected outcome: this should remove the majority of crash *volume* without touching
 architecture. Phase 0's data will confirm — and because Phase 0 shipped first, the before/after

--- a/studio-android/LightNovelLibrary/app/src/main/java/org/mewx/wenku8/global/api/Wenku8Parser.java
+++ b/studio-android/LightNovelLibrary/app/src/main/java/org/mewx/wenku8/global/api/Wenku8Parser.java
@@ -21,21 +21,21 @@ import java.util.List;
 public class Wenku8Parser {
 
     /**
-     * Parse a novel list response into (total page, aid, aid, ...).
+     * Parses a novel list response into (total page, aid, aid, ...).
      *
-     * Element 0 is the page count and the caller removes it; 0 means "unknown", which
-     * NovelItemListFragment already treats as "keep paging".
+     * <p>Element 0 is the page count and the caller removes it; 0 means "unknown", which
+     * {@code NovelItemListFragment} already treats as "keep paging".
      *
-     * <pre>
-     * &lt;?xml version="1.0" encoding="utf-8"?&gt;
-     * &lt;result&gt;
-     * &lt;page num='166'/&gt;
-     * &lt;item aid='1143'/&gt;
-     * &lt;item aid='1034'/&gt;
-     * &lt;/result&gt;
-     * </pre>
+     * <p>So the response below parses to {@code [166, 1143, 1034]}:
      *
-     * gives { 166, 1143, 1034 }.
+     * <pre>{@code
+     * <?xml version="1.0" encoding="utf-8"?>
+     * <result>
+     * <page num='166'/>
+     * <item aid='1143'/>
+     * <item aid='1034'/>
+     * </result>
+     * }</pre>
      */
     @NonNull
     public static List<Integer> parseNovelItemList(@NonNull String str) {
@@ -62,22 +62,10 @@ public class Wenku8Parser {
     }
 
     /**
-     * Parse a novel list response into (total page, aid, aid, ...), or an empty list if it is
-     * not a novel list response at all.
+     * Parses one candidate document into the list {@link #parseNovelItemList} describes.
      *
-     * Element 0 is the page count and the caller removes it; 0 means "unknown", which
-     * NovelItemListFragment already treats as "keep paging".
-     *
-     * <pre>
-     * &lt;?xml version="1.0" encoding="utf-8"?&gt;
-     * &lt;result&gt;
-     * &lt;page num='166'/&gt;
-     * &lt;item aid='1143'/&gt;
-     * &lt;item aid='1034'/&gt;
-     * &lt;/result&gt;
-     * </pre>
-     *
-     * gives { 166, 1143, 1034 }.
+     * <p>Returns an empty list when the document holds no {@code page} and no {@code item} tag,
+     * which is what tells the caller the parse recognised nothing and a retry is worth trying.
      */
     @NonNull
     private static List<Integer> parseNovelItemListAsXml(@NonNull String xml) {
@@ -137,8 +125,10 @@ public class Wenku8Parser {
     }
 
     /**
-     * Index of the first byte of the XML document within a response, or -1 if no start marker
-     * is present. Only used to skip leading noise ahead of an otherwise well-formed response.
+     * Returns the index of the first byte of the XML document within a response, or -1 when no
+     * start marker is present.
+     *
+     * <p>Only used to skip leading noise ahead of an otherwise well-formed response.
      */
     private static int indexOfDocumentStart(@NonNull String str) {
         int declaration = str.indexOf("<?xml");

--- a/studio-android/LightNovelLibrary/app/src/main/java/org/mewx/wenku8/global/api/Wenku8Parser.java
+++ b/studio-android/LightNovelLibrary/app/src/main/java/org/mewx/wenku8/global/api/Wenku8Parser.java
@@ -20,56 +20,126 @@ import java.util.List;
  */
 public class Wenku8Parser {
 
+    /**
+     * Parse a novel list response into (total page, aid, aid, ...).
+     *
+     * Element 0 is the page count and the caller removes it; 0 means "unknown", which
+     * NovelItemListFragment already treats as "keep paging".
+     *
+     * <pre>
+     * &lt;?xml version="1.0" encoding="utf-8"?&gt;
+     * &lt;result&gt;
+     * &lt;page num='166'/&gt;
+     * &lt;item aid='1143'/&gt;
+     * &lt;item aid='1034'/&gt;
+     * &lt;/result&gt;
+     * </pre>
+     *
+     * gives { 166, 1143, 1034 }.
+     */
     @NonNull
     public static List<Integer> parseNovelItemList(@NonNull String str) {
+        int totalPage = 0;
+        boolean foundPage = false;
+        List<Integer> aids = new ArrayList<>();
+
+        // Read by attribute name rather than by scanning for quoted values. The scan this
+        // replaced took any single-quoted value in document order, so it could not tell an
+        // aid from anything else quoted: <page num='166' cached='2'/> yielded a phantom novel
+        // 2, and <item type='9' aid='1143'/> a phantom novel 9. Since the API now sits behind
+        // a relay, an added attribute is a live possibility rather than a hypothetical, and
+        // it would have been invisible -- phantom aids fail to load one by one rather than
+        // failing as a list.
+        try {
+            XmlPullParserFactory factory = XmlPullParserFactory.newInstance();
+            XmlPullParser xmlPullParser = factory.newPullParser();
+            xmlPullParser.setInput(new StringReader(str));
+            int eventType = xmlPullParser.getEventType();
+
+            while (eventType != XmlPullParser.END_DOCUMENT) {
+                if (eventType == XmlPullParser.START_TAG) {
+                    if ("page".equals(xmlPullParser.getName())) {
+                        foundPage = true;
+                        String num = xmlPullParser.getAttributeValue(null, "num");
+                        if (num != null && LightTool.isInteger(num)) {
+                            totalPage = Integer.parseInt(num);
+                        }
+                    } else if ("item".equals(xmlPullParser.getName())) {
+                        String aid = xmlPullParser.getAttributeValue(null, "aid");
+                        if (aid != null && LightTool.isInteger(aid)) {
+                            aids.add(Integer.parseInt(aid));
+                            Log.v("MewX", "Add novel aid: " + aid);
+                        }
+                    }
+                }
+                eventType = xmlPullParser.next();
+            }
+        } catch (Exception e) {
+            // Deliberately not rethrown and deliberately not discarding what was collected.
+            // A response truncated mid-list still yields the items ahead of the cut, which is
+            // what the scan this replaced did, and the caller renders a short list rather
+            // than an error. Anything unparseable from the first byte falls through to the
+            // legacy scan below with aids still empty.
+            CrashReporter.recordException("Wenku8Parser.parseNovelItemList", e);
+        }
+
+        if (aids.isEmpty() && !foundPage) {
+            // Nothing recognisable. Either this is genuinely not a novel-list response -- an
+            // HTML error page, a captive-portal interstitial -- in which case the scan
+            // returns empty too and nothing is lost, or the document is well-formed only
+            // after some leading noise (a PHP notice, a relay banner) that stops
+            // XmlPullParser at the first byte while the scan reads straight past it.
+            //
+            // Kept because there is no way to tell those apart from here without data. The
+            // breadcrumb is how that data arrives: if this never fires in the wild, delete
+            // parseNovelItemListByScanning and this block with it. If it does fire, the
+            // response shape that needs handling properly will be in the report.
+            List<Integer> scanned = parseNovelItemListByScanning(str);
+            if (!scanned.isEmpty()) {
+                CrashReporter.log("parseNovelItemList: XML found nothing, scan recovered "
+                        + scanned.size() + " value(s), length=" + str.length());
+                return scanned;
+            }
+            return new ArrayList<>();
+        }
+
         List<Integer> list = new ArrayList<>();
+        list.add(totalPage);
+        list.addAll(aids);
+        return list;
+    }
 
-        // <?xml version="1.0" encoding="utf-8"?>
-        // <result>
-        // <page num='166'/>
-        // <item aid='1143'/>
-        // <item aid='1034'/>
-        // <item aid='1213'/>
-        // <item aid='1'/>
-        // <item aid='1011'/>
-        // <item aid='1192'/>
-        // <item aid='433'/>
-        // <item aid='47'/>
-        // <item aid='7'/>
-        // <item aid='374'/>
-        // </result>
-
-        // The returning list of this xml is: (total page, aids)
-        // { 166, 1143, 1034, 1213, 1, 1011, 1192, 433, 47, 7, 374 }
-
+    /**
+     * The pre-XML implementation: collect every single-quoted integer in document order.
+     *
+     * Only reached when the XML parse recognised nothing at all, to preserve its tolerance of
+     * a response that is well-formed apart from leading noise. Retained under measurement --
+     * see the caller.
+     */
+    @NonNull
+    private static List<Integer> parseNovelItemListByScanning(@NonNull String str) {
+        List<Integer> list = new ArrayList<>();
         final char SEPARATOR = '\''; // seperator
 
-        // get total page
         int beg, temp;
         beg = str.indexOf(SEPARATOR);
         temp = str.indexOf(SEPARATOR, beg + 1);
         if (beg == -1 || temp == -1) return list; // empty, this is an exception
-        if(LightTool.isInteger(str.substring(beg + 1, temp)))
+        if (LightTool.isInteger(str.substring(beg + 1, temp)))
             list.add(Integer.parseInt(str.substring(beg + 1, temp)));
         beg = temp + 1; // prepare for loop
 
-        // init array
         while (true) {
             beg = str.indexOf(SEPARATOR, beg);
             temp = str.indexOf(SEPARATOR, beg + 1);
             if (beg == -1 || temp == -1) break;
 
-            // Two separate things make this branch load-bearing. The log reads back the
-            // element just added, so from outside the branch it indexed an empty list and
-            // threw out of this @NonNull method on any token that was not an integer. And a
-            // non-integer token is skipped rather than treated as the end of the response:
-            // rejecting at the first would empty out a valid list whose XML declaration uses
-            // single quotes, since <?xml version='1.0' encoding='utf-8'?> supplies two of
-            // them ahead of the first aid. See STABILITY_PLAN.md, Phase 1 item 8.
+            // The log stays inside this branch: it reads back the element just added, so from
+            // outside it indexed an empty list and threw on any non-integer token. A
+            // non-integer token is skipped rather than ending the scan, which is what keeps a
+            // single-quoted XML declaration from emptying a valid list.
             String token = str.substring(beg + 1, temp);
             if (LightTool.isInteger(token)) {
-                // Not necessarily an aid: element 0 is the page count, and it is read here
-                // rather than above whenever the pre-loop read consumed a non-integer.
                 int value = Integer.parseInt(token);
                 list.add(value);
                 Log.v("MewX", "Add novel list value: " + value);

--- a/studio-android/LightNovelLibrary/app/src/main/java/org/mewx/wenku8/global/api/Wenku8Parser.java
+++ b/studio-android/LightNovelLibrary/app/src/main/java/org/mewx/wenku8/global/api/Wenku8Parser.java
@@ -39,6 +39,48 @@ public class Wenku8Parser {
      */
     @NonNull
     public static List<Integer> parseNovelItemList(@NonNull String str) {
+        List<Integer> list = parseNovelItemListAsXml(str);
+        if (!list.isEmpty()) return list;
+
+        // XmlPullParser stops at the first byte of anything that is not the document, so a
+        // response that is well-formed only after some leading noise -- a PHP notice, a relay
+        // banner -- parses to nothing, where the quoted-value scan this replaced read straight
+        // past it. Retry from the document start rather than keeping that scan as a fallback:
+        // it cannot tell an aid from any other quoted integer, so recovering the list that way
+        // would put the phantom novels back on exactly the responses nobody can see.
+        int documentStart = indexOfDocumentStart(str);
+        if (documentStart > 0) {
+            list = parseNovelItemListAsXml(str.substring(documentStart));
+            if (!list.isEmpty()) {
+                // How we find out whether this case is real. If a release goes by without this
+                // breadcrumb appearing, delete the retry and indexOfDocumentStart with it.
+                CrashReporter.log("parseNovelItemList: parsed after skipping " + documentStart
+                        + " leading bytes, length=" + str.length());
+            }
+        }
+        return list;
+    }
+
+    /**
+     * Parse a novel list response into (total page, aid, aid, ...), or an empty list if it is
+     * not a novel list response at all.
+     *
+     * Element 0 is the page count and the caller removes it; 0 means "unknown", which
+     * NovelItemListFragment already treats as "keep paging".
+     *
+     * <pre>
+     * &lt;?xml version="1.0" encoding="utf-8"?&gt;
+     * &lt;result&gt;
+     * &lt;page num='166'/&gt;
+     * &lt;item aid='1143'/&gt;
+     * &lt;item aid='1034'/&gt;
+     * &lt;/result&gt;
+     * </pre>
+     *
+     * gives { 166, 1143, 1034 }.
+     */
+    @NonNull
+    private static List<Integer> parseNovelItemListAsXml(@NonNull String xml) {
         int totalPage = 0;
         boolean foundPage = false;
         List<Integer> aids = new ArrayList<>();
@@ -53,7 +95,7 @@ public class Wenku8Parser {
         try {
             XmlPullParserFactory factory = XmlPullParserFactory.newInstance();
             XmlPullParser xmlPullParser = factory.newPullParser();
-            xmlPullParser.setInput(new StringReader(str));
+            xmlPullParser.setInput(new StringReader(xml));
             int eventType = xmlPullParser.getEventType();
 
             while (eventType != XmlPullParser.END_DOCUMENT) {
@@ -75,31 +117,16 @@ public class Wenku8Parser {
                 eventType = xmlPullParser.next();
             }
         } catch (Exception e) {
-            // Deliberately not rethrown and deliberately not discarding what was collected.
-            // A response truncated mid-list still yields the items ahead of the cut, which is
-            // what the scan this replaced did, and the caller renders a short list rather
-            // than an error. Anything unparseable from the first byte falls through to the
-            // legacy scan below with aids still empty.
+            // Deliberately not rethrown, and deliberately not discarding what was collected: a
+            // response truncated mid-list still yields the items ahead of the cut, as the scan
+            // did, so the caller renders a short list rather than an error. When nothing was
+            // collected the caller retries from the document start.
             CrashReporter.recordException("Wenku8Parser.parseNovelItemList", e);
         }
 
         if (aids.isEmpty() && !foundPage) {
-            // Nothing recognisable. Either this is genuinely not a novel-list response -- an
-            // HTML error page, a captive-portal interstitial -- in which case the scan
-            // returns empty too and nothing is lost, or the document is well-formed only
-            // after some leading noise (a PHP notice, a relay banner) that stops
-            // XmlPullParser at the first byte while the scan reads straight past it.
-            //
-            // Kept because there is no way to tell those apart from here without data. The
-            // breadcrumb is how that data arrives: if this never fires in the wild, delete
-            // parseNovelItemListByScanning and this block with it. If it does fire, the
-            // response shape that needs handling properly will be in the report.
-            List<Integer> scanned = parseNovelItemListByScanning(str);
-            if (!scanned.isEmpty()) {
-                CrashReporter.log("parseNovelItemList: XML found nothing, scan recovered "
-                        + scanned.size() + " value(s), length=" + str.length());
-                return scanned;
-            }
+            // Not a novel list response -- an HTML error page, a captive-portal interstitial,
+            // or a document that never started. Empty is what the caller already handles.
             return new ArrayList<>();
         }
 
@@ -110,45 +137,12 @@ public class Wenku8Parser {
     }
 
     /**
-     * The pre-XML implementation: collect every single-quoted integer in document order.
-     *
-     * Only reached when the XML parse recognised nothing at all, to preserve its tolerance of
-     * a response that is well-formed apart from leading noise. Retained under measurement --
-     * see the caller.
+     * Index of the first byte of the XML document within a response, or -1 if no start marker
+     * is present. Only used to skip leading noise ahead of an otherwise well-formed response.
      */
-    @NonNull
-    private static List<Integer> parseNovelItemListByScanning(@NonNull String str) {
-        List<Integer> list = new ArrayList<>();
-        final char SEPARATOR = '\''; // seperator
-
-        int beg, temp;
-        beg = str.indexOf(SEPARATOR);
-        temp = str.indexOf(SEPARATOR, beg + 1);
-        if (beg == -1 || temp == -1) return list; // empty, this is an exception
-        if (LightTool.isInteger(str.substring(beg + 1, temp)))
-            list.add(Integer.parseInt(str.substring(beg + 1, temp)));
-        beg = temp + 1; // prepare for loop
-
-        while (true) {
-            beg = str.indexOf(SEPARATOR, beg);
-            temp = str.indexOf(SEPARATOR, beg + 1);
-            if (beg == -1 || temp == -1) break;
-
-            // The log stays inside this branch: it reads back the element just added, so from
-            // outside it indexed an empty list and threw on any non-integer token. A
-            // non-integer token is skipped rather than ending the scan, which is what keeps a
-            // single-quoted XML declaration from emptying a valid list.
-            String token = str.substring(beg + 1, temp);
-            if (LightTool.isInteger(token)) {
-                int value = Integer.parseInt(token);
-                list.add(value);
-                Log.v("MewX", "Add novel list value: " + value);
-            }
-
-            beg = temp + 1; // prepare for next round
-        }
-
-        return list;
+    private static int indexOfDocumentStart(@NonNull String str) {
+        int declaration = str.indexOf("<?xml");
+        return declaration != -1 ? declaration : str.indexOf("<result");
     }
 
 

--- a/studio-android/LightNovelLibrary/app/src/test/java/org/mewx/wenku8/global/api/Wenku8ParserTest.java
+++ b/studio-android/LightNovelLibrary/app/src/test/java/org/mewx/wenku8/global/api/Wenku8ParserTest.java
@@ -150,14 +150,12 @@ public class Wenku8ParserTest {
         assertTrue(list.contains(1143));
     }
 
-    // The one thing the scan did better, and why it is still in the file. XmlPullParser stops
-    // at the first byte of anything that is not the document, so a response that is
-    // well-formed only after some leading noise -- a PHP notice, a relay banner -- parses to
-    // nothing. Falling back to the scan there costs nothing when the response really is not a
-    // novel list (the scan returns empty too, as the two tests above show) and recovers the
-    // list when it is.
+    // XmlPullParser stops at the first byte of anything that is not the document, so a
+    // response that is well-formed only after some leading noise -- a PHP notice, a relay
+    // banner -- parses to nothing where the quoted-value scan read straight past it. Recovered
+    // by retrying from the document start, not by scanning: see the two tests below.
     @Test
-    public void testParseNovelItemListFallsBackToScanningPastLeadingNoise() {
+    public void testParseNovelItemListRetriesPastLeadingNoise() {
         final String XML = "PHP Notice: undefined index in /srv/api.php on line 12\n" +
                 "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
                 "<result>\n" +
@@ -166,6 +164,29 @@ public class Wenku8ParserTest {
                 "</result>";
 
         assertEquals(Arrays.asList(166, 1143), Wenku8Parser.parseNovelItemList(XML));
+    }
+
+    // Why the recovery is a retry rather than a fallback to the old scan. Both of these are
+    // the leading-noise case, and the scan would have got both wrong in the way the rewrite
+    // exists to prevent -- [166, 2, 9, 1143] for the first, since it cannot tell an aid from
+    // any other quoted integer, and [7] for the second, dropping the novel because a
+    // non-integer page number shifts everything. Retrying reads attributes by name on this
+    // path too, so a response nobody can observe is parsed exactly like one that arrives clean.
+    @Test
+    public void testParseNovelItemListPastLeadingNoiseStillReadsAttributesByName() {
+        final String XML = "<!-- relay: cache MISS -->\n" +
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+                "<result><page num='166' cached='2'/><item type='9' aid='1143'/></result>";
+
+        assertEquals(Arrays.asList(166, 1143), Wenku8Parser.parseNovelItemList(XML));
+    }
+
+    @Test
+    public void testParseNovelItemListPastLeadingNoiseKeepsTheNovelWithAnUnusablePageNumber() {
+        final String XML = "PHP Notice: undefined index in /srv/api.php on line 12\n" +
+                "<result><page num='x'/><item aid='7'/></result>";
+
+        assertEquals(Arrays.asList(0, 7), Wenku8Parser.parseNovelItemList(XML));
     }
 
     // A result page with no items is not an error: the page count still comes back, and the

--- a/studio-android/LightNovelLibrary/app/src/test/java/org/mewx/wenku8/global/api/Wenku8ParserTest.java
+++ b/studio-android/LightNovelLibrary/app/src/test/java/org/mewx/wenku8/global/api/Wenku8ParserTest.java
@@ -76,14 +76,20 @@ public class Wenku8ParserTest {
         assertTrue(list.isEmpty());
     }
 
-    // Regression. "1234" above exercises the early return for input with no quotes at all; it
-    // never reached the loop. These do. Both used to throw IndexOutOfBoundsException instead
-    // of returning empty, because the log line that read back the just-added element sat
-    // outside the branch that added it -- so any input carrying two or more single-quoted
-    // values with no integer among them indexed an empty list. parseNovelItemList is @NonNull
-    // and NovelItemListFragment.AsyncGetNovelItemList catches UnsupportedEncodingException
-    // alone, so the throw escaped doInBackground and crashed the app instead of reaching the
-    // empty-list path that caller already handles.
+    /**
+     * Regression: input that reaches the loop carrying no integer among its quoted values.
+     *
+     * <p>{@code "1234"} above exercises the early return for input with no quotes at all; it
+     * never reached the loop. These do. Both used to throw {@code IndexOutOfBoundsException}
+     * instead of returning empty, because the log line that read back the just-added element
+     * sat outside the branch that added it, so any input carrying two or more single-quoted
+     * values with no integer among them indexed an empty list.
+     *
+     * <p>{@code parseNovelItemList} is {@code @NonNull} and
+     * {@code NovelItemListFragment.AsyncGetNovelItemList} catches
+     * {@code UnsupportedEncodingException} alone, so the throw escaped {@code doInBackground}
+     * and crashed the app instead of reaching the empty-list path that caller already handles.
+     */
     @Test
     public void testParseNovelItemListWellFormedNonResponse() {
         assertTrue(Wenku8Parser.parseNovelItemList(
@@ -92,10 +98,14 @@ public class Wenku8ParserTest {
                 "<html><body class='error'><p id='msg'>maintenance</p></body></html>").isEmpty());
     }
 
-    // The fix skips non-integer tokens rather than rejecting the whole response on the first
-    // one, and this is the case that decides between the two: a valid list whose declaration
-    // uses single quotes instead of double. Rejecting would return an empty list for a
-    // response that is entirely well-formed. This input threw before the fix.
+    /**
+     * A valid list whose XML declaration uses single quotes rather than double.
+     *
+     * <p>Worth keeping across the rewrite. This input threw before #186, and under the scan
+     * #186 left in place it was the case that decided against rejecting a response at its first
+     * non-integer token. The parser handles the declaration natively, so it is now
+     * unremarkable, which is the point.
+     */
     @Test
     public void testParseNovelItemListSingleQuotedXmlDeclaration() {
         final String XML = "<?xml version='1.0' encoding='utf-8'?>\n" +
@@ -107,23 +117,29 @@ public class Wenku8ParserTest {
         assertEquals(Arrays.asList(166, 1143), Wenku8Parser.parseNovelItemList(XML));
     }
 
-    // This was the characterization test for the shift quirk: the scan had no notion of which
-    // token was the page count, so a non-integer page number consumed the first aid in its
-    // place and that novel dropped out of the list, and the assertion here was the bare
-    // singleton [7]. Reading by attribute name removes the quirk rather than recording it --
-    // an unusable page count now leaves element 0 at its "unknown" default of 0, which
-    // NovelItemListFragment already handles, and the novel stays in the list.
+    /**
+     * An unusable page number leaves element 0 at 0 instead of consuming the first novel.
+     *
+     * <p>This was the characterization test for the shift quirk: the scan had no notion of
+     * which token was the page count, so a non-integer page number consumed the first aid in
+     * its place and that novel dropped out of the list, and the assertion here was the bare
+     * singleton {@code [7]}. Reading by attribute name removes the quirk rather than recording
+     * it, and 0 is the "unknown" default {@code NovelItemListFragment} already handles.
+     */
     @Test
     public void testParseNovelItemListKeepsTheNovelWhenThePageNumberIsUnusable() {
         assertEquals(Arrays.asList(0, 7),
                 Wenku8Parser.parseNovelItemList("<result><page num='x'/><item aid='7'/></result>"));
     }
 
-    // The reason for reading by attribute name rather than scanning quoted values. The scan
-    // took any single-quoted value in document order, so it could not tell an aid from
-    // anything else quoted: this input gave [166, 2, 9, 1143] -- novels 2 and 9 do not exist
-    // and would have failed to load one at a time rather than failing as a list. An added
-    // attribute on either tag is a live possibility now the API sits behind a relay.
+    /**
+     * The reason for reading by attribute name rather than scanning quoted values.
+     *
+     * <p>The scan took any single-quoted value in document order, so it could not tell an aid
+     * from anything else quoted: this input gave {@code [166, 2, 9, 1143]}. Novels 2 and 9 do
+     * not exist and would have failed to load one at a time rather than failing as a list. An
+     * added attribute on either tag is a live possibility now the API sits behind a relay.
+     */
     @Test
     public void testParseNovelItemListIgnoresAttributesThatAreNotNumOrAid() {
         final String XML = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
@@ -135,8 +151,12 @@ public class Wenku8ParserTest {
         assertEquals(Arrays.asList(166, 1143), Wenku8Parser.parseNovelItemList(XML));
     }
 
-    // A response cut off mid-list keeps the items ahead of the cut instead of collapsing to
-    // empty, which is what the scan did. The user gets a short list rather than an error.
+    /**
+     * A response cut off mid-list keeps the items ahead of the cut.
+     *
+     * <p>Collapsing to empty would be a regression against the scan: the user gets a short list
+     * rather than an error.
+     */
     @Test
     public void testParseNovelItemListKeepsWhatItReadBeforeATruncation() {
         final String XML = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
@@ -150,10 +170,13 @@ public class Wenku8ParserTest {
         assertTrue(list.contains(1143));
     }
 
-    // XmlPullParser stops at the first byte of anything that is not the document, so a
-    // response that is well-formed only after some leading noise -- a PHP notice, a relay
-    // banner -- parses to nothing where the quoted-value scan read straight past it. Recovered
-    // by retrying from the document start, not by scanning: see the two tests below.
+    /**
+     * A response that is well-formed only after some leading noise still parses.
+     *
+     * <p>{@code XmlPullParser} stops at the first byte of anything that is not the document,
+     * where the quoted-value scan read straight past it. Recovered by retrying from the
+     * document start, not by scanning: see the two tests below.
+     */
     @Test
     public void testParseNovelItemListRetriesPastLeadingNoise() {
         final String XML = "PHP Notice: undefined index in /srv/api.php on line 12\n" +
@@ -166,12 +189,16 @@ public class Wenku8ParserTest {
         assertEquals(Arrays.asList(166, 1143), Wenku8Parser.parseNovelItemList(XML));
     }
 
-    // Why the recovery is a retry rather than a fallback to the old scan. Both of these are
-    // the leading-noise case, and the scan would have got both wrong in the way the rewrite
-    // exists to prevent -- [166, 2, 9, 1143] for the first, since it cannot tell an aid from
-    // any other quoted integer, and [7] for the second, dropping the novel because a
-    // non-integer page number shifts everything. Retrying reads attributes by name on this
-    // path too, so a response nobody can observe is parsed exactly like one that arrives clean.
+    /**
+     * Why the recovery is a retry rather than a fallback to the old scan.
+     *
+     * <p>This and the test below are both the leading-noise case, and the scan would have got
+     * both wrong in the way the rewrite exists to prevent: {@code [166, 2, 9, 1143]} here,
+     * since it cannot tell an aid from any other quoted integer, and {@code [7]} below,
+     * dropping the novel because a non-integer page number shifts everything. Retrying reads
+     * attributes by name on this path too, so a response nobody can observe is parsed exactly
+     * like one that arrives clean.
+     */
     @Test
     public void testParseNovelItemListPastLeadingNoiseStillReadsAttributesByName() {
         final String XML = "<!-- relay: cache MISS -->\n" +
@@ -189,16 +216,23 @@ public class Wenku8ParserTest {
         assertEquals(Arrays.asList(0, 7), Wenku8Parser.parseNovelItemList(XML));
     }
 
-    // A result page with no items is not an error: the page count still comes back, and the
-    // caller shows an empty list rather than a failure.
+    /**
+     * A result page with no items is not an error.
+     *
+     * <p>The page count still comes back, and the caller shows an empty list rather than a
+     * failure.
+     */
     @Test
     public void testParseNovelItemListPageWithNoItems() {
         assertEquals(Collections.singletonList(1),
                 Wenku8Parser.parseNovelItemList("<result><page num='1'/></result>"));
     }
 
-    // Items with no page tag: the page count defaults to 0, which the caller reads as
-    // "unknown" and keeps paging on.
+    /**
+     * Items with no page tag: the page count defaults to 0.
+     *
+     * <p>The caller reads 0 as "unknown" and keeps paging on.
+     */
     @Test
     public void testParseNovelItemListItemsWithNoPageTag() {
         assertEquals(Arrays.asList(0, 5),

--- a/studio-android/LightNovelLibrary/app/src/test/java/org/mewx/wenku8/global/api/Wenku8ParserTest.java
+++ b/studio-android/LightNovelLibrary/app/src/test/java/org/mewx/wenku8/global/api/Wenku8ParserTest.java
@@ -107,15 +107,81 @@ public class Wenku8ParserTest {
         assertEquals(Arrays.asList(166, 1143), Wenku8Parser.parseNovelItemList(XML));
     }
 
-    // Characterization, not endorsement. The parser has no notion of which token is the page
-    // count -- it returns every integer it finds and the caller takes element 0 as the total
-    // page count. So a non-integer page number does not fail, it shifts: the first aid is
-    // consumed as the page count and that novel drops out of the list. Recorded so that
-    // changing it is a deliberate act rather than an accident.
+    // This was the characterization test for the shift quirk: the scan had no notion of which
+    // token was the page count, so a non-integer page number consumed the first aid in its
+    // place and that novel dropped out of the list, and the assertion here was the bare
+    // singleton [7]. Reading by attribute name removes the quirk rather than recording it --
+    // an unusable page count now leaves element 0 at its "unknown" default of 0, which
+    // NovelItemListFragment already handles, and the novel stays in the list.
     @Test
-    public void testParseNovelItemListNonIntegerPageNumberShiftsTheList() {
-        assertEquals(Collections.singletonList(7),
-                Wenku8Parser.parseNovelItemList("<page num='x'/><item aid='7'/>"));
+    public void testParseNovelItemListKeepsTheNovelWhenThePageNumberIsUnusable() {
+        assertEquals(Arrays.asList(0, 7),
+                Wenku8Parser.parseNovelItemList("<result><page num='x'/><item aid='7'/></result>"));
+    }
+
+    // The reason for reading by attribute name rather than scanning quoted values. The scan
+    // took any single-quoted value in document order, so it could not tell an aid from
+    // anything else quoted: this input gave [166, 2, 9, 1143] -- novels 2 and 9 do not exist
+    // and would have failed to load one at a time rather than failing as a list. An added
+    // attribute on either tag is a live possibility now the API sits behind a relay.
+    @Test
+    public void testParseNovelItemListIgnoresAttributesThatAreNotNumOrAid() {
+        final String XML = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+                "<result>\n" +
+                "<page num='166' cached='2'/>\n" +
+                "<item type='9' aid='1143'/>\n" +
+                "</result>";
+
+        assertEquals(Arrays.asList(166, 1143), Wenku8Parser.parseNovelItemList(XML));
+    }
+
+    // A response cut off mid-list keeps the items ahead of the cut instead of collapsing to
+    // empty, which is what the scan did. The user gets a short list rather than an error.
+    @Test
+    public void testParseNovelItemListKeepsWhatItReadBeforeATruncation() {
+        final String XML = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+                "<result>\n" +
+                "<page num='166'/>\n" +
+                "<item aid='1143'/>\n" +
+                "<item aid='10";
+
+        List<Integer> list = Wenku8Parser.parseNovelItemList(XML);
+        assertFalse(list.isEmpty());
+        assertTrue(list.contains(1143));
+    }
+
+    // The one thing the scan did better, and why it is still in the file. XmlPullParser stops
+    // at the first byte of anything that is not the document, so a response that is
+    // well-formed only after some leading noise -- a PHP notice, a relay banner -- parses to
+    // nothing. Falling back to the scan there costs nothing when the response really is not a
+    // novel list (the scan returns empty too, as the two tests above show) and recovers the
+    // list when it is.
+    @Test
+    public void testParseNovelItemListFallsBackToScanningPastLeadingNoise() {
+        final String XML = "PHP Notice: undefined index in /srv/api.php on line 12\n" +
+                "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+                "<result>\n" +
+                "<page num='166'/>\n" +
+                "<item aid='1143'/>\n" +
+                "</result>";
+
+        assertEquals(Arrays.asList(166, 1143), Wenku8Parser.parseNovelItemList(XML));
+    }
+
+    // A result page with no items is not an error: the page count still comes back, and the
+    // caller shows an empty list rather than a failure.
+    @Test
+    public void testParseNovelItemListPageWithNoItems() {
+        assertEquals(Collections.singletonList(1),
+                Wenku8Parser.parseNovelItemList("<result><page num='1'/></result>"));
+    }
+
+    // Items with no page tag: the page count defaults to 0, which the caller reads as
+    // "unknown" and keeps paging on.
+    @Test
+    public void testParseNovelItemListItemsWithNoPageTag() {
+        assertEquals(Arrays.asList(0, 5),
+                Wenku8Parser.parseNovelItemList("<result><item aid='5'/></result>"));
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #186, which fixed the crash in `parseNovelItemList` and left its tests behind as the baseline this change has to pass.

`parseNovelItemList` was the only method in `Wenku8Parser` that did not use `XmlPullParser`. It collected every single-quoted integer in document order and took element 0 as the page count. It now reads `page/@num` and `item/@aid` by name, like the three parsers alongside it in the same file.

**CI is green on both jobs.**

## Why, beyond consistency

The scan could not tell an aid from anything else quoted, because it never looked at attribute *names*:

| Response | Scan | Now |
|---|---|---|
| `page` tag with an extra attribute, e.g. `num='166' cached='2'` | `[166, `**`2`**`, 1143]` | `[166, 1143]` |
| `item` tag with `aid` not first, e.g. `type='9' aid='1143'` | `[166, `**`9`**`, 1143]` | `[166, 1143]` |

Novels 2 and 9 do not exist. Phantom aids fail to load *one at a time* rather than failing as a list, which is close to undiagnosable from a bug report. One attribute added to either tag is all it takes — and since the API now goes through a Cloudflare Worker relay rather than the site itself, that is a live possibility rather than a hypothetical.

It also removes the quirk #186 could only record: a non-integer page number used to consume the first aid in its place, dropping that novel from the list. The characterization test for it is now an assertion that the novel stays.

## What is deliberately preserved

Two things the scan did that a plain `XmlPullParser` rewrite would have silently lost:

- **A response truncated mid-list keeps the items ahead of the cut.** The parse exception is caught *after* collection rather than before it, so the user gets a short list where the scan also gave one, instead of an error.
- **A response that is well-formed only after leading noise still parses** — a PHP notice, a relay banner. `XmlPullParser` stops at the first byte of anything that is not the document; the scan read straight past it.

The first version of this PR kept the scan as a fallback for that second case. **Review caught the flaw and it was a real one:** a fallback that hands back the scan's output reintroduces both defects this change exists to remove — the phantom values, and the shift that drops the first novel — on exactly the responses nobody can observe. The tests did not show it because they only put a clean list through that path.

So the recovery is a **retry from the document start** instead, and the scan is deleted rather than demoted. The leading-noise path reads attributes by name like every other path, and there is one parsing implementation rather than two. Both rows below are the same responses as the table above, behind leading noise:

| Leading-noise response | Under the fallback | With the retry |
|---|---|---|
| `page` with an extra attribute, `item` with `aid` not first | `[166, 2, 9, 1143]` | `[166, 1143]` |
| `page` with a non-integer `num`, then `item aid='7'` | `[7]` — novel dropped | `[0, 7]` |

Whether leading noise happens at all is the one thing that cannot be answered offline, so **the retry records a breadcrumb when it fires**. If a release goes by without it appearing, delete the retry and `indexOfDocumentStart` with it. That is the same measure-then-act shape Phase 0 used for `loadStream`, and the deletion criterion is written into `STABILITY_PLAN.md` item 8 so it does not become permanent by inertia.

## Testing

Nine tests over this method: the four from #186 (with the shift characterization rewritten as described), plus phantom-attribute rejection, truncation tolerance, the leading-noise retry, and the two added for the fallback hole above. A page with no items and items with no page tag are covered too.

Nothing was built locally — no Android SDK is reachable from this environment — so CI is the first execution of the XML path, which #186's trigger change made possible before the merge rather than after it.