### PR TITLE
Starting the readers with aid and vid instead of a serialized volume

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -18,7 +18,7 @@ defaults:
 
 jobs:
   # Split out from the emulator job deliberately. These two run independently so that an
-  # emulator that will not boot costs the 23 instrumented tests rather than all 91: previously
+  # emulator that will not boot costs the 23 instrumented tests rather than all 101: previously
   # a single step ran assembleAlpha, the JVM tests and the instrumented tests together, so an
   # emulator failure meant the JVM tests never reported at all.
   build-and-test:

--- a/studio-android/LightNovelLibrary/STABILITY_PLAN.md
+++ b/studio-android/LightNovelLibrary/STABILITY_PLAN.md
@@ -3,10 +3,13 @@
 Status: draft, derived from a read-through of `app/` and `api/` at commit `5e00d42`.
 
 **Progress:** "Testing strategy" step 1 (move device-independent tests to the JVM), **Phase 0
-(instrumentation)** and **Phase 1 (items 1–8)** are implemented. Phase 0 has not yet *collected*
-anything — the ranking below is still inference from reading the code, and stays that way until a
-release ships and reports come back. Phase 1 was written to be safe to land without that data;
-Phase 2's ordering still needs it. Phases 2–4 are proposed, not done.
+(instrumentation)**, **Phase 1 (items 1–8)** and **Phase 2 item 1 (Intent payloads)** are
+implemented. Phase 0 has not yet *collected* anything — the ranking below is still inference from
+reading the code, and stays that way until a release ships and reports come back. Phase 1 was
+written to be safe to land without that data, and so was Phase 2.1: it fixes a size-dependent
+crash that does not need crash counts to rank. **The rest of Phase 2 does need them** — 2.2 asks
+which screen to migrate first, and that is exactly the question the data answers. Phases 3–4 are
+proposed, not done.
 
 **The Phase 1 caveat is discharged.** Those commits were written with no Android SDK and no
 emulator, so this section used to warn that `./gradlew assembleAlpha testAlphaDebugUnitTest` had
@@ -316,20 +319,52 @@ comparison is actually available this time.
 Only worth doing once Phase 1 has landed and the crash rate has visibly dropped, so the
 effect of each change is measurable.
 
-1. **Pass IDs, not objects, through Intents.** Replace the `VolumeList` extra with `aid` +
-   `vid` and re-read the volume from the local cache on the receiving side. Kills
-   `TransactionTooLargeException` permanently and makes the reader survive process death for
-   free, since ints in an Intent always restore. This is the highest-value item in the plan.
+1. **Pass IDs, not objects, through Intents — implemented, unverified on a device.** The
+   `VolumeList` extra is gone: the readers take `aid` + `vid` and rebuild the volume from the
+   cached novel index. Kills `TransactionTooLargeException` permanently and makes the reader
+   survive process death for free, since ints in an Intent always restore.
 
-   **Check the cache assumption first — it does not currently hold.** "Re-read the volume from
-   the local cache" assumes `intro/<aid>-volume.xml` is on disk by the time the reader starts.
-   It is written only by `NovelInfoActivity.AsyncUpdateCacheTask`, the explicit download/refresh
-   action. The ordinary online load (`FetchInfoAsyncTask`'s `volumeTask`) fetches exactly the
-   same XML and never writes it, so for any novel the user has merely opened, the receiving
-   Activity would find nothing to read and the reader would fail to open — a worse bug than the
-   one being fixed. Persisting that response in the sender is a prerequisite, not a detail, and
-   it is worth doing on its own: it is also what lets the reader rebuild itself after process
-   death, which is Phase 3's problem for these screens.
+   **The cache assumption did not hold, and a correction to an earlier note here.** That note
+   said `intro/<aid>-volume.xml` was written "only by `AsyncUpdateCacheTask`, the explicit
+   download action". Wrong — there are three writers: adding a novel to the bookshelf
+   (`NovelInfoActivity:299`), the download/refresh task (`:958`), and bookshelf cloud sync
+   (`FavFragment:421`). All three are bookshelf paths, so the file is present for anything in
+   the user's bookshelf, which is most of what anyone reads. The real gap was narrower than
+   stated: a novel *browsed and opened* from a list or search without ever being favourited.
+   Narrower, but still fatal to this item, since that novel can reach a reader.
+
+   `FetchInfoAsyncTask` now writes the index whenever one arrives from the network, after the
+   parse rather than straight off the wire so an unparseable response cannot overwrite a good
+   cached index with a broken one. That also refreshes a stale bookshelf copy, which previously
+   only happened on explicit sync or download.
+
+   The rest of the item:
+
+   - `GlobalConfig.cacheVolumeIndex` / `loadCachedVolume` own the file, so the `"intro"` folder
+     and `<aid>-volume.xml` filename stop being spelled out at each call site.
+   - `Wenku8Parser.findVolumeByVid` is the lookup, and is pure logic with JVM tests. It skips
+     null entries: `getVolumeList` appends on the closing tag, so a stray closing tag with no
+     opening one leaves a null in the list, and the lookup must not be what turns a malformed
+     index into a crash.
+   - **`VolumeList` and `ChapterInfo` are no longer `Serializable`.** Nothing else serialized
+     them. Dropping the interface is what makes this permanent rather than a convention — the
+     shortcut is now a compile error, not a code review.
+   - `VerticalReaderActivity` takes no volume at all. Phase 1 found it read the extra and never
+     dereferenced it; the field and its Phase 1 breadcrumb are deleted rather than migrated.
+
+   **One case this makes worse, deliberately.** A device whose storage cannot be written could
+   previously still read a novel, because the volume travelled in the Intent. Now the reader
+   cannot open at all. Every other write in the app fails silently the same way, so a failed
+   cache write is recorded — without it there would be no way to tell that story apart from a
+   reader that simply refuses to open. The alternative fixes are worse: re-fetching the index on
+   a cache miss puts a network round trip in front of the reader's startup, and an in-memory
+   handoff would be root cause 2 all over again.
+
+   **What CI cannot check here.** The reader flow is not covered by the JVM suite or by the two
+   instrumented tests, so the smoke test is manual: open a novel *not* in the bookshelf and read
+   a chapter; next/previous chapter across a volume boundary; the resume dialog; the vertical
+   reader from the engine picker; then a bookshelf novel offline. Developer Options → **Don't
+   keep activities** while reading is the one that exercises what this item was for.
 2. **Retire `AsyncTask`.** Do not rewrite all 24 at once. Introduce one small helper
    (`ExecutorService` + main-thread `Handler`, or `androidx.lifecycle` if you are open to
    adding it) and migrate screen by screen, starting with whichever Phase 0 shows is
@@ -496,9 +531,12 @@ inverts the negative test cases. See step 1.
 | Ship | Contents | Risk |
 |---|---|---|
 | v1.30.0 | Phase 0 instrumentation only | none |
-| v1.30.1 | Phase 1 items 1–7 — **implemented, CI green**; item 8 pending its first CI run | low, mechanical |
-| v1.31 | Phase 2.1 (Intent payloads) + highest-crash screen from 2.2 | medium |
+| v1.30.1 | Phase 1 items 1–8 — **implemented, CI green** | low, mechanical |
+| v1.31 | Phase 2.1 (Intent payloads) — **implemented, needs a device smoke test**; then highest-crash screen from 2.2 | medium |
 | v1.32+ | Remainder of Phase 2, Phase 3 | medium |
+
+Nothing has shipped yet, so Phase 0 is still collecting nothing and the ordering below 2.1
+remains inference. That is a deliberate choice for now, not an oversight.
 
 The important structural point: **Phase 0 before Phase 1**. Without crash data the ranking
 above is inference from reading code, and inference will misallocate effort.

--- a/studio-android/LightNovelLibrary/STABILITY_PLAN.md
+++ b/studio-android/LightNovelLibrary/STABILITY_PLAN.md
@@ -37,6 +37,39 @@ are not. The loop that does work for a change made without a device:
 Guard clauses, anything touching a view, and the Robolectric tests still cannot be executed
 anywhere but CI and a device.
 
+### Picking this up on a machine with an SDK
+
+Everything above describes working *without* one. On a normal development machine none of it
+applies, and there is work waiting that only that machine can do.
+
+**Run what CI runs, plus the part CI cannot judge.**
+
+```
+./gradlew assembleAlpha testAlphaDebugUnitTest      # 78 JVM tests, seconds
+./gradlew connectedAlphaDebugAndroidTest            # 23 tests, needs a device or emulator
+```
+
+**Then the manual pass, which nothing automated covers.** The reader flow has no test above the
+storage layer — not in the JVM suite, not in the instrumented one — so Phase 2.1 is compiled and
+unit-tested but has never been *run*. On a device:
+
+1. A novel **not** in the bookshelf: open it, read a chapter. This is the path that had no
+   cached index before Phase 2.1 and the one most likely to be wrong.
+2. Next and previous chapter, including across a volume boundary.
+3. The resume dialog ("jump to last read").
+4. The vertical reader, via the engine picker.
+5. A bookshelf novel with the network off.
+6. Developer Options → **Don't keep activities**, while reading. This is what Phase 2.1 was for,
+   and it is the same switch Phase 3 needs, so it is worth leaving on for a while.
+
+A long series matters for 1 and 2: the crash Phase 2.1 removes was size-dependent, so a novel
+with hundreds of chapters is the one that used to fail.
+
+**What that machine unblocks beyond this.** Phase 2.2 onwards wants crash data and so is still
+gated on a release. But Phase 3 (`onSaveInstanceState`) and Phase 4's OOM/bitmap question are
+both device work that no amount of CI substitutes for, and "Don't keep activities" is the tool
+for the first of them.
+
 ## Diagnosis
 
 The app is ~18k lines and structurally sound at the feature level. The instability is not
@@ -360,11 +393,13 @@ effect of each change is measurable.
    a cache miss puts a network round trip in front of the reader's startup, and an in-memory
    handoff would be root cause 2 all over again.
 
-   **What CI cannot check here.** The reader flow is not covered by the JVM suite or by the two
-   instrumented tests, so the smoke test is manual: open a novel *not* in the bookshelf and read
-   a chapter; next/previous chapter across a volume boundary; the resume dialog; the vertical
-   reader from the engine picker; then a bookshelf novel offline. Developer Options → **Don't
-   keep activities** while reading is the one that exercises what this item was for.
+   **What is tested, and what is not.** `findVolumeByVid` is pure and has JVM tests. Nothing
+   else here does: neither the cache the readers now depend on nor the reader flow itself has
+   automated coverage, so Phase 2.1 is compiled and unit-tested but has never been run. See
+   "Picking this up on a machine with an SDK" for the manual pass it needs.
+
+   Device coverage for `cacheVolumeIndex` and `loadCachedVolume` is a follow-up, and has to be:
+   writing it turned up two storage bugs that have to be fixed before any such test can pass.
 2. **Retire `AsyncTask`.** Do not rewrite all 24 at once. Introduce one small helper
    (`ExecutorService` + main-thread `Handler`, or `androidx.lifecycle` if you are open to
    adding it) and migrate screen by screen, starting with whichever Phase 0 shows is
@@ -438,7 +473,7 @@ appears at first glance. The problem was never the count, it was *where* they ru
 
 | Location | Before | Now | Runs on |
 |---|---|---|---|
-| `app/src/test` | 3 files / 10 tests | **12 files / 68 tests** | JVM, seconds |
+| `app/src/test` | 3 files / 10 tests | **12 files / 78 tests** | JVM, seconds |
 | `app/src/androidTest` | 8 files / 31 tests | **2 files / 23 tests** | emulator, minutes |
 | `api/src/test` | 1 file | 1 file | JVM |
 
@@ -452,7 +487,7 @@ never reported at all. Four changes to `.github/workflows/android-ci.yml`:
 
 1. **Split into two jobs.** JVM tests no longer depend on an emulator booting. This is the whole
    payoff of having moved those tests off the device: an emulator that will not start now costs
-   the 23 instrumented tests instead of all 91.
+   the 23 instrumented tests instead of all 101.
 2. **Enable KVM.** The failure was `ShellCommandUnresponsiveException` during `installCommit`,
    with the emulator console also failing to start — the signature of an emulator running
    unaccelerated. `android-emulator-runner` needs an explicit udev rule on `ubuntu-latest`;

--- a/studio-android/LightNovelLibrary/app/src/main/java/org/mewx/wenku8/activity/NovelInfoActivity.java
+++ b/studio-android/LightNovelLibrary/app/src/main/java/org/mewx/wenku8/activity/NovelInfoActivity.java
@@ -564,7 +564,7 @@ public class NovelInfoActivity extends BaseMaterialActivity {
                     // jump to reader activity
                     Intent intent = new Intent(NovelInfoActivity.this, Wenku8ReaderActivityV1.class);
                     intent.putExtra("aid", aid);
-                    intent.putExtra("volume", volumeList_bak);
+                    intent.putExtra("vid", volumeList_bak.vid);
                     intent.putExtra("cid", cid);
 
                     // test does file exist
@@ -665,6 +665,22 @@ public class NovelInfoActivity extends BaseMaterialActivity {
             // Parse Volume
             listVolume = Wenku8Parser.getVolumeList(novelFullVolume);
             if (listVolume.isEmpty()) return -1;
+
+            // The readers are started with aid + vid and rebuild the volume from this file, so
+            // it has to exist for any novel that can reach a reader -- not just the ones added
+            // to the bookshelf or downloaded, which were the only writers before. Written after
+            // the parse rather than straight off the wire so a response that does not parse
+            // cannot overwrite a good cached index with a broken one.
+            //
+            // Recorded when it fails because this is the one case the change makes worse: a
+            // device whose storage cannot be written could previously still read a novel, since
+            // the volume travelled in the Intent, and now cannot open the reader at all. Every
+            // other write in the app fails silently the same way, so without this there would
+            // be no way to tell that story apart from a reader that simply refuses to open.
+            if (!fromLocal && !GlobalConfig.cacheVolumeIndex(aid, novelFullVolume)) {
+                CrashReporter.log("Failed to cache the volume index (aid=" + aid
+                        + ", length=" + novelFullVolume.length() + "); readers cannot open");
+            }
 
             // Check local volume files exists, express in another color
             for (VolumeList vl : listVolume) {
@@ -847,7 +863,7 @@ public class NovelInfoActivity extends BaseMaterialActivity {
                 // jump to reader activity
                 Intent intent = new Intent(NovelInfoActivity.this, Wenku8ReaderActivityV1.class);
                 intent.putExtra("aid", aid);
-                intent.putExtra("volume", volumeList);
+                intent.putExtra("vid", volumeList.vid);
                 intent.putExtra("cid", ci.cid);
 
                 // test does file exist
@@ -885,7 +901,7 @@ public class NovelInfoActivity extends BaseMaterialActivity {
 
                         Intent intent = new Intent(NovelInfoActivity.this, readerClass);
                         intent.putExtra("aid", aid);
-                        intent.putExtra("volume", volumeList);
+                        intent.putExtra("vid", volumeList.vid);
                         intent.putExtra("cid", ci.cid);
 
                         // test does file exist

--- a/studio-android/LightNovelLibrary/app/src/main/java/org/mewx/wenku8/activity/VerticalReaderActivity.java
+++ b/studio-android/LightNovelLibrary/app/src/main/java/org/mewx/wenku8/activity/VerticalReaderActivity.java
@@ -31,7 +31,6 @@ import org.mewx.wenku8.R;
 import org.mewx.wenku8.component.ScrollViewNoFling;
 import org.mewx.wenku8.global.GlobalConfig;
 import org.mewx.wenku8.global.api.OldNovelContentParser;
-import org.mewx.wenku8.global.api.VolumeList;
 import org.mewx.wenku8.api.Wenku8API;
 import org.mewx.wenku8.network.LightNetwork;
 
@@ -49,7 +48,8 @@ public class VerticalReaderActivity extends AppCompatActivity {
     // private vars
     private String from = "";
     private int aid, cid;
-    private VolumeList volumeList= null; // for extended function
+    // No volume here. This screen renders from aid/cid alone -- the field it used to keep was
+    // assigned from the Intent and never read -- so it takes no vid and loads no index.
     private ProgressDialogHelper pDialog = null;
     private final AsyncTaskTracker tracker = new AsyncTaskTracker();
     private ScrollViewNoFling svTextListLayout = null;
@@ -80,7 +80,6 @@ public class VerticalReaderActivity extends AppCompatActivity {
 
         // fetch values
         aid = getIntent().getIntExtra("aid", 1);
-        volumeList = (VolumeList) getIntent().getSerializableExtra("volume");
         cid = getIntent().getIntExtra("cid",1);
         from = getIntent().getStringExtra("from");
 
@@ -88,14 +87,6 @@ public class VerticalReaderActivity extends AppCompatActivity {
         CrashReporter.setKey(CrashReporter.Keys.READER_MODE, "vertical");
         CrashReporter.setKey(CrashReporter.Keys.NOVEL_AID, aid);
         CrashReporter.setKey(CrashReporter.Keys.CHAPTER_CID, cid);
-        if (volumeList == null) {
-            // Unlike Wenku8ReaderActivityV1 this stays a breadcrumb rather than becoming a
-            // finish(): volumeList is only ever assigned here and never dereferenced -- this
-            // screen renders from aid/cid alone -- so bailing out would break a case that
-            // currently works. Kept so the two readers' counts stay comparable.
-            CrashReporter.log("Vertical reader started without a 'volume' extra (aid=" + aid
-                    + ", cid=" + cid + ", from=" + from + ")");
-        }
 
         // UIL setting
         if(ImageLoader.getInstance() == null || !ImageLoader.getInstance().isInited()) {

--- a/studio-android/LightNovelLibrary/app/src/main/java/org/mewx/wenku8/global/GlobalConfig.java
+++ b/studio-android/LightNovelLibrary/app/src/main/java/org/mewx/wenku8/global/GlobalConfig.java
@@ -19,6 +19,8 @@ import com.nostra13.universalimageloader.core.display.FadeInBitmapDisplayer;
 import org.mewx.wenku8.MyApp;
 import org.mewx.wenku8.R;
 import org.mewx.wenku8.api.Wenku8API;
+import org.mewx.wenku8.global.api.VolumeList;
+import org.mewx.wenku8.global.api.Wenku8Parser;
 import org.mewx.wenku8.network.LightUserSession;
 import org.mewx.wenku8.util.CrashReporter;
 import org.mewx.wenku8.util.LightCache;
@@ -329,6 +331,43 @@ public class GlobalConfig {
         // input no separator
         return writeFullSaveFileContent(subFolderName + File.separator
                 + fileName, s);
+    }
+
+    /** Name of the cached chapter index for a novel, relative to the "intro" save subfolder. */
+    @NonNull
+    public static String getVolumeIndexFileName(int aid) {
+        return aid + "-volume.xml";
+    }
+
+    /**
+     * Caches the chapter index of a novel so a reader started later can rebuild it from
+     * {@code aid} and {@code vid} alone.
+     *
+     * <p>The readers take the volume as ids rather than as a serialized object, which is what
+     * keeps a long series from overflowing the Binder transaction buffer and what lets a reader
+     * restore itself after process death. Both depend on this file being present, so it is
+     * written whenever a novel index arrives from the network, not only when the novel is
+     * added to the bookshelf or downloaded.
+     */
+    public static boolean cacheVolumeIndex(int aid, @NonNull String volumeXml) {
+        return writeFullFileIntoSaveFolder("intro", getVolumeIndexFileName(aid), volumeXml);
+    }
+
+    /**
+     * Loads one volume of a novel out of the index cached by {@link #cacheVolumeIndex}, or null
+     * when the index is missing, unparseable, or holds no volume with that {@code vid}.
+     *
+     * <p>Null is an ordinary outcome here rather than an error: the cache is deleted when a
+     * novel leaves the bookshelf, so a reader restored by the system long after the fact can
+     * legitimately find nothing to read.
+     */
+    @Nullable
+    public static VolumeList loadCachedVolume(int aid, int vid) {
+        String xml = loadFullFileFromSaveFolder("intro", getVolumeIndexFileName(aid));
+        if (xml.isEmpty()) {
+            return null;
+        }
+        return Wenku8Parser.findVolumeByVid(Wenku8Parser.getVolumeList(xml), vid);
     }
 
     /** Book shelf */

--- a/studio-android/LightNovelLibrary/app/src/main/java/org/mewx/wenku8/global/api/ChapterInfo.java
+++ b/studio-android/LightNovelLibrary/app/src/main/java/org/mewx/wenku8/global/api/ChapterInfo.java
@@ -1,12 +1,13 @@
 package org.mewx.wenku8.global.api;
 
-import java.io.Serializable;
-
 /**
  * Created by MewX on 2015/5/13.
  * Chapter Info.
+ *
+ * <p>Not Serializable, for the reason given on {@link VolumeList}: it was only ever serialized
+ * as part of one.
  */
-public class ChapterInfo implements Serializable {
+public class ChapterInfo {
     public int cid;
     public String chapterName;
 }

--- a/studio-android/LightNovelLibrary/app/src/main/java/org/mewx/wenku8/global/api/VolumeList.java
+++ b/studio-android/LightNovelLibrary/app/src/main/java/org/mewx/wenku8/global/api/VolumeList.java
@@ -1,13 +1,18 @@
 package org.mewx.wenku8.global.api;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 
 /**
  * Created by MewX on 2015/5/13.
  * Volume List.
+ *
+ * <p>Deliberately not Serializable. This carries every ChapterInfo in the volume, so passing
+ * one through an Intent put a long series over the ~1MB Binder transaction buffer and threw
+ * TransactionTooLargeException on exactly the most-engaged readers. The readers take aid + vid
+ * and rebuild it from the cached index instead, and dropping the interface is what stops that
+ * shortcut being available again.
  */
-public class VolumeList implements Serializable {
+public class VolumeList {
     public String volumeName;
     public int vid;
     public boolean inLocal = false;

--- a/studio-android/LightNovelLibrary/app/src/main/java/org/mewx/wenku8/global/api/Wenku8Parser.java
+++ b/studio-android/LightNovelLibrary/app/src/main/java/org/mewx/wenku8/global/api/Wenku8Parser.java
@@ -1,6 +1,7 @@
 package org.mewx.wenku8.global.api;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.util.Log;
 
 import org.mewx.wenku8.util.LightTool;
@@ -308,6 +309,23 @@ public class Wenku8Parser {
             CrashReporter.recordException("Wenku8Parser.getVolumeList", e);
         }
         return l;
+    }
+
+    /**
+     * Returns the volume carrying {@code vid}, or null when the list holds no such volume.
+     *
+     * <p>Null entries in the list are skipped rather than dereferenced: {@link #getVolumeList}
+     * appends on the closing tag, so a stray closing tag with no opening one puts a null in
+     * there.
+     */
+    @Nullable
+    public static VolumeList findVolumeByVid(@NonNull List<VolumeList> volumes, int vid) {
+        for (VolumeList volume : volumes) {
+            if (volume != null && volume.vid == vid) {
+                return volume;
+            }
+        }
+        return null;
     }
 
     /**

--- a/studio-android/LightNovelLibrary/app/src/main/java/org/mewx/wenku8/reader/activity/Wenku8ReaderActivityV1.java
+++ b/studio-android/LightNovelLibrary/app/src/main/java/org/mewx/wenku8/reader/activity/Wenku8ReaderActivityV1.java
@@ -75,7 +75,7 @@ public class Wenku8ReaderActivityV1 extends BaseMaterialActivity {
     // vars
     private FirebaseAnalytics mFirebaseAnalytics;
     private String from = "";
-    private int aid, cid;
+    private int aid, cid, vid;
     private String forcejump;
     private VolumeList volumeList= null;
     private List<OldNovelContentParser.NovelContent> nc = new ArrayList<>();
@@ -100,7 +100,13 @@ public class Wenku8ReaderActivityV1 extends BaseMaterialActivity {
 
         // fetch values
         aid = getIntent().getIntExtra("aid", 1);
-        volumeList = (VolumeList) getIntent().getSerializableExtra("volume");
+        // Rebuilt from the cached novel index rather than arriving as a Serializable extra. A
+        // VolumeList carries every ChapterInfo in the volume, so a long series could overflow
+        // the ~1MB Binder transaction buffer on the way in; ints cannot. It also means the
+        // volume survives process death, because the system restores these extras and the
+        // reader can load the rest again from disk.
+        vid = getIntent().getIntExtra("vid", -1);
+        volumeList = GlobalConfig.loadCachedVolume(aid, vid);
         cid = getIntent().getIntExtra("cid", 1);
         from = getIntent().getStringExtra("from");
         forcejump = getIntent().getStringExtra("forcejump");
@@ -123,10 +129,11 @@ public class Wenku8ReaderActivityV1 extends BaseMaterialActivity {
         CrashReporter.setKey(CrashReporter.Keys.NOVEL_AID, aid);
         CrashReporter.setKey(CrashReporter.Keys.CHAPTER_CID, cid);
         if (volumeList == null) {
-            // The breadcrumb still distinguishes "extra absent" from "deserialisation failed",
-            // but the dereference below is no longer reached: bail out instead of NPE-ing.
-            // Phase 2 removes the cause by passing aid/vid rather than the object itself.
-            CrashReporter.log("Reader started without a 'volume' extra (aid=" + aid
+            // Now means the cached index is missing, unparseable, or holds no such vid, rather
+            // than an Intent extra that failed to deserialise. Reachable in ordinary use: the
+            // index is deleted when a novel leaves the bookshelf, so a reader the system
+            // restores long afterwards can find nothing left to read.
+            CrashReporter.log("Reader found no cached volume (aid=" + aid + ", vid=" + vid
                     + ", cid=" + cid + ", from=" + from + ")");
             Toast.makeText(this, R.string.reader_load_failed, Toast.LENGTH_SHORT).show();
             finish();
@@ -733,7 +740,7 @@ public class Wenku8ReaderActivityV1 extends BaseMaterialActivity {
                                                         .setPositiveButton(R.string.dialog_positive_yes, (dialog, which) -> {
                                                             Intent intent = new Intent(Wenku8ReaderActivityV1.this, Wenku8ReaderActivityV1.class);
                                                             intent.putExtra("aid", aid);
-                                                            intent.putExtra("volume", volumeList);
+                                                            intent.putExtra("vid", volumeList.vid);
                                                             intent.putExtra("cid", volumeList.chapterList.get(i_bak - 1).cid);
                                                             intent.putExtra("from", from); // from cloud
                                                             startActivity(intent);
@@ -765,7 +772,7 @@ public class Wenku8ReaderActivityV1 extends BaseMaterialActivity {
                                                         .setPositiveButton(R.string.dialog_positive_yes, (dialog, which) -> {
                                                             Intent intent = new Intent(Wenku8ReaderActivityV1.this, Wenku8ReaderActivityV1.class);
                                                             intent.putExtra("aid", aid);
-                                                            intent.putExtra("volume", volumeList);
+                                                            intent.putExtra("vid", volumeList.vid);
                                                             intent.putExtra("cid", volumeList.chapterList.get(i_bak + 1).cid);
                                                             intent.putExtra("from", from); // from cloud
                                                             startActivity(intent);
@@ -873,7 +880,7 @@ public class Wenku8ReaderActivityV1 extends BaseMaterialActivity {
                                 .setPositiveButton(R.string.dialog_positive_yes, (dialog, which) -> {
                                     Intent intent = new Intent(Wenku8ReaderActivityV1.this, Wenku8ReaderActivityV1.class);
                                     intent.putExtra("aid", aid);
-                                    intent.putExtra("volume", volumeList);
+                                    intent.putExtra("vid", volumeList.vid);
                                     intent.putExtra("cid", volumeList.chapterList.get(i_bak + 1).cid);
                                     intent.putExtra("from", from); // from cloud
                                     startActivity(intent);
@@ -911,7 +918,7 @@ public class Wenku8ReaderActivityV1 extends BaseMaterialActivity {
                                 .setPositiveButton(R.string.dialog_positive_yes, (dialog, which) -> {
                                     Intent intent = new Intent(Wenku8ReaderActivityV1.this, Wenku8ReaderActivityV1.class);
                                     intent.putExtra("aid", aid);
-                                    intent.putExtra("volume", volumeList);
+                                    intent.putExtra("vid", volumeList.vid);
                                     intent.putExtra("cid", volumeList.chapterList.get(i_bak - 1).cid);
                                     intent.putExtra("from", from); // from cloud
                                     startActivity(intent);

--- a/studio-android/LightNovelLibrary/app/src/test/java/org/mewx/wenku8/global/api/Wenku8ParserTest.java
+++ b/studio-android/LightNovelLibrary/app/src/test/java/org/mewx/wenku8/global/api/Wenku8ParserTest.java
@@ -399,6 +399,52 @@ public class Wenku8ParserTest {
         assertTrue(volumeLists.isEmpty());
     }
 
+    /**
+     * The lookup a reader performs on startup, now that it is given a vid rather than a volume.
+     */
+    @Test
+    public void testFindVolumeByVid() {
+        VolumeList first = new VolumeList();
+        first.vid = 41748;
+        VolumeList second = new VolumeList();
+        second.vid = 41749;
+
+        assertSame(second, Wenku8Parser.findVolumeByVid(Arrays.asList(first, second), 41749));
+    }
+
+    /**
+     * A vid that is not in the list is an ordinary outcome, not an error.
+     *
+     * <p>It is what a reader sees when the cached index is for a different novel, or when the
+     * novel's chapter list changed under it, and it is why the reader treats null as "show the
+     * failure toast and finish" rather than as something to assert against.
+     */
+    @Test
+    public void testFindVolumeByVidNotPresent() {
+        VolumeList only = new VolumeList();
+        only.vid = 41748;
+
+        assertNull(Wenku8Parser.findVolumeByVid(Collections.singletonList(only), 999));
+        assertNull(Wenku8Parser.findVolumeByVid(Collections.emptyList(), 41748));
+    }
+
+    /**
+     * Null entries are skipped rather than dereferenced.
+     *
+     * <p>{@link Wenku8Parser#getVolumeList} appends on the closing tag, so a stray closing tag
+     * with no opening one leaves a null in the list it returns. Looking a vid up in that list
+     * must not be the thing that turns a malformed index into a crash.
+     */
+    @Test
+    public void testFindVolumeByVidSkipsNullEntries() {
+        VolumeList present = new VolumeList();
+        present.vid = 41748;
+
+        assertSame(present,
+                Wenku8Parser.findVolumeByVid(Arrays.asList(null, present, null), 41748));
+        assertNull(Wenku8Parser.findVolumeByVid(Arrays.asList(null, present), 999));
+    }
+
     @Test
     public void testParseReviewList() {
         ReviewList reviewList = new ReviewList();


### PR DESCRIPTION
Phase 2.1 of `STABILITY_PLAN.md` — the plan's highest-value item, and root cause 3 in full.

**Needs a manual pass on a device before it ships.** The reader flow has no automated coverage at any level. The list is at the bottom, and is also written into the plan under "Picking this up on a machine with an SDK" so it survives this PR.

## What changed

`VolumeList` carries every `ChapterInfo` in the volume and was passed through an Intent from seven call sites. A long-running series put the transaction over the ~1MB Binder buffer and threw `TransactionTooLargeException` — size-dependent, so it hit exactly the most-engaged readers on the longest series.

The readers now take `aid` + `vid` and rebuild the volume from the cached novel index. That also makes them survive process death for free: ints in an Intent always restore, and the rest can be read again from disk.

**`VolumeList` and `ChapterInfo` are no longer `Serializable`.** Nothing else serialized them, and dropping the interface is what makes this permanent — putting one in an Intent is a compile error now, not something review has to keep catching.

## A correction to the plan's note on this item

The plan said the cached index was written "only by `AsyncUpdateCacheTask`, the explicit download action". That was wrong. There are three writers — adding to the bookshelf (`NovelInfoActivity:299`), download/refresh (`:958`), and cloud sync (`FavFragment:421`). All three are bookshelf paths, so the index is present for anything in the user's bookshelf. The gap was narrower than I described but still fatal to this item: a novel merely *browsed and opened* has no index, and it can reach a reader.

`FetchInfoAsyncTask` now writes the index whenever one arrives from the network — after the parse rather than off the wire, so an unparseable response cannot overwrite a good cached index with a broken one. That also refreshes a stale bookshelf copy.

## The rest

- `GlobalConfig.cacheVolumeIndex` / `loadCachedVolume` own the file, so the `"intro"` folder and the `{aid}-volume.xml` filename stop being spelled out at each call site.
- `Wenku8Parser.findVolumeByVid` is the lookup — pure logic, three JVM tests. It skips null entries, since `getVolumeList` appends on the closing tag and a stray closing tag leaves a null in the list.
- `VerticalReaderActivity` takes no volume at all. Phase 1 established it read the extra and never dereferenced it, so the field and its breadcrumb are deleted rather than migrated.

## One case this makes worse, deliberately

A device whose storage cannot be written could previously still read a novel, because the volume travelled in the Intent. Now the reader cannot open at all. A failed cache write is recorded so that story can be told apart from a reader that simply refuses to open.

The alternatives are worse: re-fetching the index on a miss puts a network round trip in front of reader startup and makes it async, in the Activity this plan has spent the most effort making lifecycle-safe; an in-memory handoff would be root cause 2 again.

## Testing

| Level | Coverage |
|---|---|
| JVM | `findVolumeByVid` — match, absent vid, null entries. Also checked in a standalone harness over seven inputs. |
| Device / emulator | **None yet** — see below. |
| Reader flow | **None.** |

**Device coverage for the index cache is a follow-up PR, and had to be split out.** Writing `GlobalConfigVolumeIndexTest` turned up two storage bugs that have to be fixed before any such test can pass — `MyAppTest` leaving a mocked context in a process-wide static, and `SaveFileMigration.getInternalSavePath` caching a path built from it for the life of the process. Those are independent of this change and are being sent separately rather than smuggled in here.

**The manual pass, which none of the above reaches.** A long series matters for 1 and 2 — the crash this removes was size-dependent.

1. A novel **not** in the bookshelf — open it, read a chapter. This is the path that had no cached index before.
2. Next / previous chapter, including across a volume boundary.
3. The resume dialog ("jump to last read").
4. The vertical reader from the engine picker.
5. A bookshelf novel with the network off.
6. Developer Options → **Don't keep activities**, while reading. This is the one the item exists for.