### PR TITLE
Not caching a save path built from a context that was not ready

### DIFF
--- a/studio-android/LightNovelLibrary/STABILITY_PLAN.md
+++ b/studio-android/LightNovelLibrary/STABILITY_PLAN.md
@@ -489,6 +489,27 @@ which is now on the test classpath for that purpose.
 tests run, but its malformed-input behaviour differs from Android's parser, which silently
 inverts the negative test cases. See step 1.
 
+**A test used to break storage for every test that ran after it.** Worth knowing before writing
+any instrumented test that touches saved files, because the symptom appears in the wrong place
+entirely — the failing test is fine, and something that ran before it is not.
+
+`MyApp.context` is a process-wide static. `MyAppTest` sets it to a Mockito mock in one method
+and to `null` in the other, and used to leave it that way. `SaveFileMigration.getInternalSavePath`
+then asked `MyApp` for a context, got the mock, called `getFilesDir()` on it — `null`, as Mockito
+returns for an unstubbed method — and built the literal string `"null/"`, which it cached in a
+static for the rest of the process. Every save after that went to a relative `null/...` path that
+cannot be created, and the external fallback is unwritable on API 29+, so writes simply failed.
+
+Fixed at both ends, because either alone leaves a hole. `MyAppTest` restores the real application
+context in `@After`. `getInternalSavePath` no longer caches a path it could not resolve: it
+returns `""` for that call and tries again next time. The second half matters beyond the tests —
+a transient null context during startup would have had the same permanent effect on a real
+device, silently, and nothing would have reported it. `SaveFileMigrationTest` pins the invariant
+that the path really is under the app's files dir, and fails loudly if the ordering bug returns.
+
+This is root cause 2 reaching the test suite, and a reminder that a static cache holding a value
+derived from something that might not be ready yet is a trap wherever it appears.
+
 ---
 
 ## Suggested sequencing

--- a/studio-android/LightNovelLibrary/app/src/androidTest/java/org/mewx/wenku8/MyAppTest.java
+++ b/studio-android/LightNovelLibrary/app/src/androidTest/java/org/mewx/wenku8/MyAppTest.java
@@ -2,7 +2,9 @@ package org.mewx.wenku8;
 
 import android.app.Activity;
 import androidx.test.filters.SmallTest;
+import androidx.test.platform.app.InstrumentationRegistry;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
@@ -24,6 +26,22 @@ public class MyAppTest {
     @Before
     public void init() {
         initMocks(this);
+    }
+
+    /**
+     * Puts the real application context back.
+     *
+     * <p>{@code MyApp.context} is process-wide static, and both tests here leave it holding a
+     * mock or null. Anything that runs afterwards and asks {@code MyApp} for a context gets that
+     * instead of the real one — {@code SaveFileMigration.getInternalSavePath} did, and cached a
+     * save path built from a mocked {@code getFilesDir()} for the rest of the run, which broke
+     * every storage test in the suite. Root cause 2 of STABILITY_PLAN.md, reaching the tests.
+     */
+    @After
+    public void restoreRealContext() {
+        when(myApp.getApplicationContextLocal())
+                .thenReturn(InstrumentationRegistry.getInstrumentation().getTargetContext());
+        myApp.onCreate();
     }
 
     @Test

--- a/studio-android/LightNovelLibrary/app/src/androidTest/java/org/mewx/wenku8/MyAppTest.java
+++ b/studio-android/LightNovelLibrary/app/src/androidTest/java/org/mewx/wenku8/MyAppTest.java
@@ -1,6 +1,7 @@
 package org.mewx.wenku8;
 
 import android.app.Activity;
+import android.content.Context;
 import androidx.test.filters.SmallTest;
 import androidx.test.platform.app.InstrumentationRegistry;
 
@@ -10,8 +11,11 @@ import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
+import java.lang.reflect.Field;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -36,12 +40,26 @@ public class MyAppTest {
      * instead of the real one — {@code SaveFileMigration.getInternalSavePath} did, and cached a
      * save path built from a mocked {@code getFilesDir()} for the rest of the run, which broke
      * every storage test in the suite. Root cause 2 of STABILITY_PLAN.md, reaching the tests.
+     *
+     * <p>Written to the field rather than driven through {@code onCreate}. Going through
+     * {@code onCreate} would mean stubbing a method on {@code myApp}, which is a real instance
+     * and not a mock, so whether the stub takes at all is a question about Mockito rather than
+     * about this test — and a restore that quietly does not restore is worse than none, since it
+     * fails somewhere else entirely. It would also re-run every {@code Application#onCreate}
+     * side effect after each test. The assertion is here for the same reason: this method has no
+     * value unless it demonstrably worked.
      */
     @After
-    public void restoreRealContext() {
-        when(myApp.getApplicationContextLocal())
-                .thenReturn(InstrumentationRegistry.getInstrumentation().getTargetContext());
-        myApp.onCreate();
+    public void restoreRealContext() throws Exception {
+        Context real = InstrumentationRegistry.getInstrumentation().getTargetContext()
+                .getApplicationContext();
+
+        Field contextField = MyApp.class.getDeclaredField("context");
+        contextField.setAccessible(true);
+        contextField.set(null, real);
+
+        assertSame("MyApp.context was not restored; later tests will see a stale context",
+                real, MyApp.getContext());
     }
 
     @Test

--- a/studio-android/LightNovelLibrary/app/src/androidTest/java/org/mewx/wenku8/util/SaveFileMigrationTest.java
+++ b/studio-android/LightNovelLibrary/app/src/androidTest/java/org/mewx/wenku8/util/SaveFileMigrationTest.java
@@ -1,0 +1,47 @@
+package org.mewx.wenku8.util;
+
+import static org.junit.Assert.assertTrue;
+
+import androidx.test.filters.SmallTest;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import org.junit.Test;
+
+import java.io.File;
+
+/**
+ * The internal save path, which everything the app persists is built on.
+ *
+ * <p>Deliberately blunt. The bug this guards against was not a wrong path, it was the literal
+ * string {@code "null/"} — {@code getFilesDir()} came back null once, got concatenated, and was
+ * cached in a static for the life of the process, so every save afterwards went to a relative
+ * path that cannot be created. Asserting the path is really under the app's files dir catches
+ * that, and catches it wherever it comes from: a context that is not ready yet, or a test that
+ * left a mock in {@code MyApp}'s static and moved on.
+ *
+ * <p>That second one is why this runs on a device rather than being a unit test. It only fails
+ * when the whole suite runs together in one process, which is exactly the condition it is here
+ * to police.
+ */
+@SmallTest
+public class SaveFileMigrationTest {
+
+    @Test
+    public void testInternalSavePathIsUnderTheAppFilesDir() {
+        final String path = SaveFileMigration.getInternalSavePath();
+        final String filesDir = InstrumentationRegistry.getInstrumentation().getTargetContext()
+                .getFilesDir().getAbsolutePath();
+
+        assertTrue("internal save path was \"" + path + "\", expected it under " + filesDir,
+                path.startsWith(filesDir));
+    }
+
+    @Test
+    public void testInternalSavePathEndsWithASeparator() {
+        // Callers append a subfolder straight onto it, so a missing trailing separator would
+        // silently produce sibling files like ".../filessaves" rather than ".../files/saves".
+        final String path = SaveFileMigration.getInternalSavePath();
+
+        assertTrue("internal save path was \"" + path + "\"", path.endsWith(File.separator));
+    }
+}

--- a/studio-android/LightNovelLibrary/app/src/main/java/org/mewx/wenku8/util/SaveFileMigration.java
+++ b/studio-android/LightNovelLibrary/app/src/main/java/org/mewx/wenku8/util/SaveFileMigration.java
@@ -1,6 +1,7 @@
 package org.mewx.wenku8.util;
 
 import android.annotation.TargetApi;
+import android.content.Context;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Environment;
@@ -78,7 +79,18 @@ public class SaveFileMigration {
 
     public static String getInternalSavePath() {
         if (savedInternalPath == null) {
-            savedInternalPath = MyApp.getContext().getFilesDir() + File.separator;
+            // Only cache a path that came from a real files dir. This used to be
+            // MyApp.getContext().getFilesDir() + File.separator, which turns into the literal
+            // string "null/" when either is null -- and then caches it for the life of the
+            // process, so every save afterwards goes to a relative "null/..." path that cannot
+            // be created. A transient null this early is enough to break storage permanently.
+            Context context = MyApp.getContext();
+            File filesDir = context == null ? null : context.getFilesDir();
+            if (filesDir == null) {
+                Log.d(TAG, "getInternalSavePath: no files dir yet, not caching");
+                return "";
+            }
+            savedInternalPath = filesDir + File.separator;
         }
         return savedInternalPath;
     }

--- a/studio-android/LightNovelLibrary/app/src/main/java/org/mewx/wenku8/util/SaveFileMigration.java
+++ b/studio-android/LightNovelLibrary/app/src/main/java/org/mewx/wenku8/util/SaveFileMigration.java
@@ -29,11 +29,27 @@ public class SaveFileMigration {
     private static Uri overrideExternalPathUrl = null;
 
     public static void markMigrationCompleted() {
-        LightCache.saveFile(getInternalSavePath(), SIGNAL_FILE_NAME, "".getBytes(), false);
+        String path = getInternalSavePath();
+        if (path.isEmpty()) {
+            // See getInternalSavePath: empty means the files dir was not resolvable yet. These
+            // two are the only callers that hand the path straight to LightCache as a directory
+            // rather than concatenating onto it, and those helpers index path.charAt(length - 1)
+            // without checking, so an empty one throws StringIndexOutOfBoundsException. Skipping
+            // is the honest outcome: there is nowhere to write the signal file yet, and the next
+            // call resolves the path again.
+            Log.d(TAG, "markMigrationCompleted: no internal save path yet, skipping");
+            return;
+        }
+        LightCache.saveFile(path, SIGNAL_FILE_NAME, "".getBytes(), false);
     }
 
     public static void revertMigrationStatus() {
-        LightCache.deleteFile(getInternalSavePath(), SIGNAL_FILE_NAME);
+        String path = getInternalSavePath();
+        if (path.isEmpty()) {
+            Log.d(TAG, "revertMigrationStatus: no internal save path yet, skipping");
+            return;
+        }
+        LightCache.deleteFile(path, SIGNAL_FILE_NAME);
     }
 
     /**


### PR DESCRIPTION
Split out of #188 at your request. Independent of it — this can merge on its own, and ahead of it.

## The bug

`SaveFileMigration.getInternalSavePath` was:

```java
savedInternalPath = MyApp.getContext().getFilesDir() + File.separator;
```

When either half is null that expression does not throw — it produces the literal string `"null/"`. And it is cached in a static on first use, so that becomes the app's internal save path **for the rest of the process**. Every save afterwards goes to a relative `null/...` path that cannot be created, and since the external fallback is unwritable on API 29+, writes simply fail. Nothing reports it.

I found this because it made every storage test fail on the emulator, but **it is not a test-only problem**: any transient null context early in startup has the same permanent effect on a real device.

## The fix, in three parts

**`getInternalSavePath` no longer caches a path it could not resolve.** It resolves the files dir first, returns `""` and retries next time if there isn't one, and only caches a real value. Still cached once real, so this costs nothing in the normal case.

**`markMigrationCompleted` and `revertMigrationStatus` skip when the path is empty.** These two are the only callers that hand the path to `LightCache` as a *directory* argument, and those helpers index `path.charAt(length - 1)` without checking — so returning `""` would have turned a silent bogus write into `StringIndexOutOfBoundsException`, on exactly the startup path this change exists to make safe. Everything else concatenates onto the path, where an empty string degrades to a relative path rather than throwing. (Caught in review.)

**`MyAppTest` restores the real application context in `@After`, and proves it did.** `MyApp.context` is a process-wide static; that test sets it to a Mockito mock in one method and to `null` in the other, and left it that way. Everything that ran afterwards got the mock, and a mocked `getFilesDir()` returns null — which is what fed the string above. Root cause 2 of `STABILITY_PLAN.md` reaching the test suite: the failing test is fine, and something that ran before it is not.

The restore writes the static directly rather than driving `onCreate` with a stubbed method. `myApp` is a real instance, not a mock, so whether such a stub takes effect is a question about Mockito rather than about the test — and a restore that quietly does nothing is worse than none, because it surfaces somewhere else entirely and much later. It asserts the value came back for the same reason. (Also caught in review, and the more valuable of the two: the first version of this PR may have been passing by test order rather than by working.)

## Testing

`SaveFileMigrationTest` pins the invariant — the path is really under the app's files dir, and ends with a separator so callers appending a subfolder don't produce `.../filessaves`.

It is deliberately blunt, and deliberately instrumented rather than a unit test. The failure it guards against only happens when the whole suite runs together in one process, which is exactly the condition it is there to police.

Between that and the assertion in `MyAppTest`'s teardown, a green instrumented run is now evidence rather than a coincidence: if the restore fails, `MyAppTest` fails, instead of some unrelated storage test failing later.

The plan's testing strategy carries the trap, since the symptom shows up nowhere near the cause.